### PR TITLE
feat: support NamespacedPoolInterface in cache tracing

### DIFF
--- a/src/Cache/TraceableCachePool.php
+++ b/src/Cache/TraceableCachePool.php
@@ -30,7 +30,7 @@ class TraceableCachePool implements CacheInterface, AdapterInterface, ResetInter
     private ?TracerInterface $tracer = null;
     private ?bool $enabled = null;
 
-    private readonly CacheItemPoolInterface $pool;
+    protected CacheItemPoolInterface $pool;
 
     public function __construct(
         CacheItemPoolInterface $pool,

--- a/src/Cache/TraceableNamespacedCachePool.php
+++ b/src/Cache/TraceableNamespacedCachePool.php
@@ -13,8 +13,6 @@ use Symfony\Contracts\Cache\NamespacedPoolInterface;
  */
 final class TraceableNamespacedCachePool extends TraceableCachePool implements NamespacedPoolInterface
 {
-    private readonly NamespacedPoolInterface $namespacedPool;
-
     public function __construct(
         CacheItemPoolInterface $pool,
         string $tracerName,
@@ -25,14 +23,17 @@ final class TraceableNamespacedCachePool extends TraceableCachePool implements N
         }
 
         parent::__construct($pool, $tracerName, $poolName);
-        $this->namespacedPool = $pool;
     }
 
     public function withSubNamespace(string $namespace): static
     {
-        $inner = $this->namespacedPool->withSubNamespace($namespace);
+        if (!$this->pool instanceof NamespacedPoolInterface) {
+            throw new \BadMethodCallException(\sprintf('Cannot call "%s::withSubNamespace()": the inner pool doesn\'t implement "%s".', get_debug_type($this->pool), NamespacedPoolInterface::class));
+        }
 
-        /** @var static */
-        return new self($inner, $this->tracerName, $this->poolName);
+        $clone = clone $this;
+        $clone->pool = $this->pool->withSubNamespace($namespace);
+
+        return $clone;
     }
 }

--- a/src/Cache/TraceableNamespacedCachePool.php
+++ b/src/Cache/TraceableNamespacedCachePool.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Cache;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
+
+/**
+ * Extends {@see TraceableCachePool} for namespaced cache pools,
+ * delegating withSubNamespace() to the inner pool.
+ */
+final class TraceableNamespacedCachePool extends TraceableCachePool implements NamespacedPoolInterface
+{
+    private readonly NamespacedPoolInterface $namespacedPool;
+
+    public function __construct(
+        CacheItemPoolInterface $pool,
+        string $tracerName,
+        string $poolName,
+    ) {
+        if (!$pool instanceof NamespacedPoolInterface) {
+            throw new \LogicException(\sprintf('Pool "%s" does not implement NamespacedPoolInterface.', $poolName));
+        }
+
+        parent::__construct($pool, $tracerName, $poolName);
+        $this->namespacedPool = $pool;
+    }
+
+    public function withSubNamespace(string $namespace): static
+    {
+        $inner = $this->namespacedPool->withSubNamespace($namespace);
+
+        /** @var static */
+        return new self($inner, $this->tracerName, $this->poolName);
+    }
+}

--- a/src/DependencyInjection/Compiler/CacheTracingPass.php
+++ b/src/DependencyInjection/Compiler/CacheTracingPass.php
@@ -8,8 +8,10 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Traceway\OpenTelemetryBundle\Cache\TraceableCachePool;
+use Traceway\OpenTelemetryBundle\Cache\TraceableNamespacedCachePool;
 use Traceway\OpenTelemetryBundle\Cache\TraceableTagAwareCachePool;
 
 /**
@@ -52,8 +54,18 @@ final class CacheTracingPass implements CompilerPassInterface
             $class = $definition->getClass();
 
             $isTagAware = null !== $class && is_subclass_of($class, TagAwareCacheInterface::class);
+            $isNamespaced = !$isTagAware
+                && interface_exists(NamespacedPoolInterface::class)
+                && null !== $class
+                && is_subclass_of($class, NamespacedPoolInterface::class);
 
-            $decoratorClass = $isTagAware ? TraceableTagAwareCachePool::class : TraceableCachePool::class;
+            if ($isTagAware) {
+                $decoratorClass = TraceableTagAwareCachePool::class;
+            } elseif ($isNamespaced) {
+                $decoratorClass = TraceableNamespacedCachePool::class;
+            } else {
+                $decoratorClass = TraceableCachePool::class;
+            }
             $decoratorId = $id . '.otel';
             $innerId = $decoratorId . '.inner';
 

--- a/src/DependencyInjection/Compiler/CacheTracingPass.php
+++ b/src/DependencyInjection/Compiler/CacheTracingPass.php
@@ -17,7 +17,8 @@ use Traceway\OpenTelemetryBundle\Cache\TraceableTagAwareCachePool;
 /**
  * Decorates all services tagged with 'cache.pool' with our tracing wrapper.
  *
- * Tag-aware pools get {@see TraceableTagAwareCachePool}; others get
+ * Tag-aware pools get {@see TraceableTagAwareCachePool}, namespaced pools
+ * (Symfony 7.3+) get {@see TraceableNamespacedCachePool}, and others get
  * {@see TraceableCachePool}. Decoration priority -32 ensures we wrap
  * after Symfony's own TraceableAdapter (profiler) at -16.
  */

--- a/tests/Cache/TraceableNamespacedCachePoolTest.php
+++ b/tests/Cache/TraceableNamespacedCachePoolTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
+use Traceway\OpenTelemetryBundle\Cache\TraceableNamespacedCachePool;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+final class TraceableNamespacedCachePoolTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        if (!interface_exists(NamespacedPoolInterface::class)) {
+            self::markTestSkipped('NamespacedPoolInterface not available.');
+        }
+
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownOTel();
+    }
+
+    public function testWithSubNamespaceReturnsNewInstance(): void
+    {
+        $inner = $this->createNamespacedPool();
+        $pool = new TraceableNamespacedCachePool($inner, 'test-tracer', 'cache.app');
+
+        $namespaced = $pool->withSubNamespace('users');
+
+        self::assertInstanceOf(TraceableNamespacedCachePool::class, $namespaced);
+        self::assertNotSame($pool, $namespaced);
+    }
+
+    public function testWithSubNamespaceDelegatesToInnerPool(): void
+    {
+        $inner = $this->createNamespacedPool();
+        $pool = new TraceableNamespacedCachePool($inner, 'test-tracer', 'cache.app');
+
+        $namespaced = $pool->withSubNamespace('users');
+
+        $value = $namespaced->get('key', fn () => 'computed');
+        self::assertSame('cached', $value);
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        self::assertSame('cache.get key', $spans[0]->getName());
+    }
+
+    public function testConstructorRejectsNonNamespacedPool(): void
+    {
+        $inner = $this->createMock(CacheItemPoolInterface::class);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('does not implement NamespacedPoolInterface');
+
+        new TraceableNamespacedCachePool($inner, 'test-tracer', 'cache.app');
+    }
+
+    private function createNamespacedPool(): AdapterInterface&NamespacedPoolInterface
+    {
+        return new class implements AdapterInterface, CacheInterface, NamespacedPoolInterface {
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed { return 'cached'; }
+            public function delete(string $key): bool { return true; }
+            public function withSubNamespace(string $namespace): static { return clone $this; }
+            public function getItem(mixed $key): CacheItem { throw new \LogicException('Not implemented'); }
+            public function getItems(array $keys = []): iterable { return []; }
+            public function hasItem(mixed $key): bool { return false; }
+            public function clear(string $prefix = ''): bool { return true; }
+            public function deleteItem(string $key): bool { return true; }
+            public function deleteItems(array $keys): bool { return true; }
+            public function save(CacheItemInterface $item): bool { return true; }
+            public function saveDeferred(CacheItemInterface $item): bool { return true; }
+            public function commit(): bool { return true; }
+        };
+    }
+}

--- a/tests/Cache/TraceableNamespacedCachePoolTest.php
+++ b/tests/Cache/TraceableNamespacedCachePoolTest.php
@@ -51,7 +51,7 @@ final class TraceableNamespacedCachePoolTest extends TestCase
         $namespaced = $pool->withSubNamespace('users');
 
         $value = $namespaced->get('key', fn () => 'computed');
-        self::assertSame('cached', $value);
+        self::assertSame('namespaced', $value);
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
@@ -71,9 +71,10 @@ final class TraceableNamespacedCachePoolTest extends TestCase
     private function createNamespacedPool(): AdapterInterface&NamespacedPoolInterface
     {
         return new class implements AdapterInterface, CacheInterface, NamespacedPoolInterface {
-            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed { return 'cached'; }
+            private string $value = 'cached';
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed { return $this->value; }
             public function delete(string $key): bool { return true; }
-            public function withSubNamespace(string $namespace): static { return clone $this; }
+            public function withSubNamespace(string $namespace): static { $clone = clone $this; $clone->value = 'namespaced'; return $clone; }
             public function getItem(mixed $key): CacheItem { throw new \LogicException('Not implemented'); }
             public function getItems(array $keys = []): iterable { return []; }
             public function hasItem(mixed $key): bool { return false; }

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -9,7 +9,9 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
 use Traceway\OpenTelemetryBundle\Cache\TraceableCachePool;
+use Traceway\OpenTelemetryBundle\Cache\TraceableNamespacedCachePool;
 use Traceway\OpenTelemetryBundle\Cache\TraceableTagAwareCachePool;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\CacheTracingPass;
 
@@ -31,7 +33,10 @@ final class CacheTracingPassTest extends TestCase
         self::assertTrue($container->hasDefinition('cache.app.otel'));
 
         $decorator = $container->getDefinition('cache.app.otel');
-        self::assertSame(TraceableCachePool::class, $decorator->getClass());
+        $expectedClass = interface_exists(NamespacedPoolInterface::class) && is_subclass_of(FilesystemAdapter::class, NamespacedPoolInterface::class)
+            ? TraceableNamespacedCachePool::class
+            : TraceableCachePool::class;
+        self::assertSame($expectedClass, $decorator->getClass());
         self::assertSame('test-tracer', $decorator->getArgument('$tracerName'));
         self::assertSame('cache.app', $decorator->getArgument('$poolName'));
     }


### PR DESCRIPTION
 ## Summary
  - Adds `TraceableNamespacedCachePool` subclass implementing `NamespacedPoolInterface` (Symfony 7.3+)
  - `CacheTracingPass` selects it via `interface_exists()` + `is_subclass_of()` guard — Symfony < 7.3
  unaffected
  - Same pattern as existing `TraceableTagAwareCachePool` for `TagAwareCacheInterface`

  Closes #11

  Reported-by: @SebLours