### PR TITLE
feat: export Monolog logs via OpenTelemetry Logs API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Monolog log export via OpenTelemetry Logs API** — new `OtelLogHandler` bridges Monolog records into the OTel Logs API with native trace correlation, per-channel instrumentation scopes, microsecond timestamp precision, and exception attributes. Off by default; enable with `log_export_enabled: true` (also requires `symfony/monolog-bundle`)
+- **`log_export_enabled` / `log_export_level` config keys** — opt-in toggle and minimum severity filter for the new OTel log export pipeline
+- **`OtelLoggerFlushSubscriber`** — flushes the `LoggerProvider` on `kernel.terminate` and `console.terminate` so log records queued in `BatchLogRecordProcessor` are not lost when a request finishes faster than the batch processor's scheduled flush interval
+- **Re-entrance guard in `OtelLogHandler`** — prevents infinite loops when the OTel exporter itself emits a log record (e.g. an instrumented HTTP client logging a failed OTLP send), matching `TraceableHttpClient`'s `$inFlight` pattern
+- **Loud failure when `log_export_enabled: true` but `symfony/monolog-bundle` is missing** — `OpenTelemetryExtension::prepend()` now throws `LogicException` with a clear install hint instead of silently no-op'ing (the previous behavior masked the misconfiguration because `prependExtensionConfig` stores config for nonexistent extensions without error)
+
 ## [1.5.0] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Pure-PHP OpenTelemetry instrumentation for Symfony — automatic tracing for HTT
 
 Works with any OpenTelemetry-compatible backend: [Traceway](https://tracewayapp.com), [Jaeger](https://www.jaegertracing.io/), [Zipkin](https://zipkin.io/), [Datadog](https://www.datadoghq.com/), [Grafana Tempo](https://grafana.com/oss/tempo/), [Honeycomb](https://www.honeycomb.io/), and more.
 
+- **Pure PHP** — no C extension required; installs on every managed Symfony host
+- **Production-ready** — stable since v1.0, PHPStan level 10 with no baseline, supports Symfony 6.4 LTS through 8.x
+- **Correct under load** — Messenger trace context propagates across async queue boundaries, Doctrine DBAL 3 and 4 both CI-tested, re-entrance guards prevent export-path recursion in HttpClient and the log handler
+
 ## Quick Start
 
 ```bash
@@ -24,17 +28,12 @@ OTEL_SERVICE_NAME=my-symfony-app
 OTEL_TRACES_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+# Optional: OTEL_RESOURCE_ATTRIBUTES=service.version=1.0
 ```
 
-> Use `http/json` by default. Switch to `http/protobuf` only if you have `ext-protobuf` installed — see [Performance](#performance).
+> Use `http/json` unless you have `ext-protobuf` installed — see [Performance](#performance).
 
-Optionally, it is possible to also provide a version identifier using e.g.:
-
-```env
-OTEL_RESOURCE_ATTRIBUTES=service.version=1.0
-```
-
-That's it — every HTTP request, console command, outgoing HTTP call, Messenger job, DB query, cache operation, and Twig render is now traced automatically.
+That's it. Every HTTP request, console command, outgoing call, Messenger job, DB query, cache operation, and Twig render is now traced.
 
 ## What Gets Traced
 
@@ -44,7 +43,7 @@ That's it — every HTTP request, console command, outgoing HTTP call, Messenger
 | **Console commands** | SERVER | Command name, arguments, exit code, exceptions |
 | **HttpClient** | CLIENT | Outgoing requests with W3C context propagation, OTLP endpoint auto-excluded, re-entrance guard |
 | **Messenger** | PRODUCER/CONSUMER | Message class, transport, W3C context propagation across async boundaries |
-| **Doctrine DBAL** | CLIENT | SQL queries (parameterized), transactions, db system/namespace auto-detection. Requires `doctrine/dbal` ^3.6 or ^4.0 |
+| **Doctrine DBAL** | CLIENT | SQL queries (parameterized), transactions, db system/namespace auto-detection. **DBAL 3.6+ and 4.x both CI-tested** |
 | **Cache** | INTERNAL | `get` (hit/miss), `delete`, `invalidateTags` with pool name. Requires `symfony/cache` |
 | **Twig** | INTERNAL | Template name, nested includes. Requires `twig/twig` |
 | **Monolog: log correlation** | — | Inject `trace_id` + `span_id` into every log record. Requires `monolog/monolog` |
@@ -132,34 +131,15 @@ class OrderService
 }
 ```
 
-Mock in tests:
-
-```php
-$tracing = $this->createStub(TracingInterface::class);
-$tracing->method('trace')->willReturnCallback(fn ($name, $cb) => $cb());
-```
+Mock in tests with `$this->createStub(TracingInterface::class)` and have `trace()` invoke the callback directly.
 
 ## Performance
 
-The bundle adds **near-zero overhead** when the SDK is not active — every component checks `isEnabled()` and short-circuits immediately.
+Near-zero overhead when the SDK is inactive — every component short-circuits via `isEnabled()`. When tracing is on, almost all cost is in span export, not instrumentation. PHP-FPM has no background thread, so `BatchSpanProcessor` flushes during request shutdown.
 
-When tracing is active, most overhead comes from the SDK's span export, not instrumentation. PHP-FPM has no background thread, so `BatchSpanProcessor` flushes during request shutdown.
+**Use `http/json` unless you have `ext-protobuf` installed.** PHP's native `json_encode()` is faster than the pure-PHP protobuf encoder, which adds significant CPU overhead under load. Switch to `http/protobuf` only with the C extension installed.
 
-### Export Protocol
-
-| Setup | Recommendation |
-|---|---|
-| `ext-protobuf` **installed** | Use `http/protobuf` — smallest payloads, fastest serialization |
-| `ext-protobuf` **not installed** | Use `http/json` — `json_encode()` is native C in PHP, much faster than pure-PHP protobuf |
-
-> **Do not** use `http/protobuf` without `ext-protobuf`. The pure-PHP protobuf encoder adds significant CPU overhead under load.
-
-### Tips
-
-1. **Local OTel Collector** — export to `localhost:4318` (sub-ms latency), let the Collector forward asynchronously
-2. **Sampling** — `OTEL_TRACES_SAMPLER=parentbased_traceidratio` + `OTEL_TRACES_SAMPLER_ARG=0.1` traces 10% of requests
-3. **Install `ext-protobuf`** — if using `http/protobuf`, the C extension reduces serialization overhead dramatically ([pecl.php.net/protobuf](https://pecl.php.net/package/protobuf))
-4. **Exclude noisy paths** — use `excluded_paths` and `cache_excluded_pools` to reduce span volume
+For high-traffic apps: run a local OTel Collector at `localhost:4318` (sub-ms latency) and let it forward asynchronously, enable head sampling with `OTEL_TRACES_SAMPLER=parentbased_traceidratio` + `OTEL_TRACES_SAMPLER_ARG=0.1`, and use `excluded_paths` / `cache_excluded_pools` to drop noisy spans.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Symfony Version](https://img.shields.io/badge/symfony-%3E%3D6.4-000000.svg)](https://symfony.com)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Pure-PHP OpenTelemetry instrumentation for Symfony — automatic tracing for HTTP, Console, HttpClient, Messenger, Doctrine DBAL, Cache, and Twig, plus Monolog log-trace correlation. No C extension required.
+Pure-PHP OpenTelemetry instrumentation for Symfony — automatic tracing for HTTP, Console, HttpClient, Messenger, Doctrine DBAL, Cache, and Twig, plus Monolog log-trace correlation and OpenTelemetry log export. No C extension required.
 
 Works with any OpenTelemetry-compatible backend: [Traceway](https://tracewayapp.com), [Jaeger](https://www.jaegertracing.io/), [Zipkin](https://zipkin.io/), [Datadog](https://www.datadoghq.com/), [Grafana Tempo](https://grafana.com/oss/tempo/), [Honeycomb](https://www.honeycomb.io/), and more.
 
@@ -47,7 +47,8 @@ That's it — every HTTP request, console command, outgoing HTTP call, Messenger
 | **Doctrine DBAL** | CLIENT | SQL queries (parameterized), transactions, db system/namespace auto-detection. Requires `doctrine/dbal` ^3.6 or ^4.0 |
 | **Cache** | INTERNAL | `get` (hit/miss), `delete`, `invalidateTags` with pool name. Requires `symfony/cache` |
 | **Twig** | INTERNAL | Template name, nested includes. Requires `twig/twig` |
-| **Monolog** | — | Injects `trace_id` + `span_id` into every log record. Requires `monolog/monolog` |
+| **Monolog: log correlation** | — | Inject `trace_id` + `span_id` into every log record. Requires `monolog/monolog` |
+| **Monolog: log export** | — | Export log records via the OTel Logs API with native trace correlation and per-channel instrumentation scope. Requires `symfony/monolog-bundle`. **Off by default** |
 
 Additional: response propagation (Server-Timing headers), `Tracing` helper for manual spans, full [OTel semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/).
 
@@ -87,7 +88,10 @@ open_telemetry:
     twig_enabled: true
     twig_excluded_templates: ['@WebProfiler/', '@Debug/']
 
-    monolog_enabled: true
+    monolog_enabled: true            # inject trace_id/span_id into log records
+
+    log_export_enabled: false        # export logs via OTel Logs API (requires symfony/monolog-bundle)
+    log_export_level: debug          # debug | info | notice | warning | error | critical | alert | emergency
 ```
 
 ### Environment Variables
@@ -96,7 +100,8 @@ open_telemetry:
 |---|---|---|
 | `OTEL_PHP_AUTOLOAD_ENABLED` | `true` | Enable SDK auto-initialization |
 | `OTEL_SERVICE_NAME` | `my-symfony-app` | Service name shown in your backend |
-| `OTEL_TRACES_EXPORTER` | `otlp` | Exporter type (`otlp`, `zipkin`, `console`, `none`) |
+| `OTEL_TRACES_EXPORTER` | `otlp` | Traces exporter (`otlp`, `zipkin`, `console`, `none`) |
+| `OTEL_LOGS_EXPORTER` | `otlp` | Logs exporter (`otlp`, `console`, `none`) — only used when `log_export_enabled: true` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | Collector/backend endpoint |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/json` | Protocol (`http/json`, `http/protobuf`, `grpc`) |
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -108,6 +108,18 @@ final class Configuration implements ConfigurationInterface
                     ->info('Inject trace_id and span_id into Monolog log records for log-trace correlation.')
                     ->defaultTrue()
                 ->end()
+                ->booleanNode('log_export_enabled')
+                    ->info('Export Monolog logs via OpenTelemetry (OTLP). Requires a configured OTel LoggerProvider (e.g. via OTEL_LOGS_EXPORTER env var).')
+                    ->defaultFalse()
+                ->end()
+                ->scalarNode('log_export_level')
+                    ->info('Minimum Monolog level to export via OTel (debug, info, notice, warning, error, critical, alert, emergency).')
+                    ->defaultValue('debug')
+                    ->validate()
+                        ->ifNotInArray(['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'])
+                        ->thenInvalid('Invalid log level %s')
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -16,8 +16,10 @@ use Doctrine\DBAL\Driver\Middleware as DoctrineMiddleware;
 use Traceway\OpenTelemetryBundle\Doctrine\Middleware\TraceableMiddleware as DoctrineTraceableMiddleware;
 use Traceway\OpenTelemetryBundle\EventSubscriber\ConsoleSubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetrySubscriber;
+use Traceway\OpenTelemetryBundle\EventSubscriber\OtelLoggerFlushSubscriber;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
 use Traceway\OpenTelemetryBundle\Tracing;
+use Traceway\OpenTelemetryBundle\Monolog\OtelLogHandler;
 use Traceway\OpenTelemetryBundle\Monolog\TraceContextProcessor;
 use Traceway\OpenTelemetryBundle\Twig\OpenTelemetryTwigExtension;
 
@@ -25,28 +27,39 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
 {
     public function prepend(ContainerBuilder $container): void
     {
-        if (!$this->isMessengerAvailable()) {
-            return;
-        }
-
         $configs = $container->getExtensionConfig($this->getAlias());
         $config = $this->processConfiguration(new Configuration(), $configs);
 
-        if (!$config['messenger_enabled']) {
-            return;
-        }
-
-        $container->prependExtensionConfig('framework', [
-            'messenger' => [
-                'buses' => [
-                    'messenger.bus.default' => [
-                        'middleware' => [
-                            OpenTelemetryMiddleware::class,
+        if ($config['messenger_enabled'] && $this->isMessengerAvailable()) {
+            $container->prependExtensionConfig('framework', [
+                'messenger' => [
+                    'buses' => [
+                        'messenger.bus.default' => [
+                            'middleware' => [
+                                OpenTelemetryMiddleware::class,
+                            ],
                         ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
+        }
+
+        if ($config['log_export_enabled']) {
+            if (!$container->hasExtension('monolog')) {
+                throw new \LogicException(
+                    'The "open_telemetry.log_export_enabled" option requires symfony/monolog-bundle to be installed and enabled. Run "composer require symfony/monolog-bundle" or set "log_export_enabled: false".'
+                );
+            }
+
+            $container->prependExtensionConfig('monolog', [
+                'handlers' => [
+                    'opentelemetry' => [
+                        'type' => 'service',
+                        'id' => OtelLogHandler::class,
+                    ],
+                ],
+            ]);
+        }
     }
 
     public function load(array $configs, ContainerBuilder $container): void
@@ -124,6 +137,17 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $monologDef = new Definition(TraceContextProcessor::class);
             $monologDef->addTag('monolog.processor');
             $container->setDefinition(TraceContextProcessor::class, $monologDef);
+        }
+
+        if ($config['log_export_enabled'] && $container->hasExtension('monolog')) {
+            $handlerDef = new Definition(OtelLogHandler::class);
+            $handlerDef->setArgument('$level', $config['log_export_level']);
+            $handlerDef->setAutoconfigured(true);
+            $container->setDefinition(OtelLogHandler::class, $handlerDef);
+
+            $flushDef = new Definition(OtelLoggerFlushSubscriber::class);
+            $flushDef->setAutoconfigured(true);
+            $container->setDefinition(OtelLoggerFlushSubscriber::class, $flushDef);
         }
     }
 

--- a/src/EventSubscriber/OtelLoggerFlushSubscriber.php
+++ b/src/EventSubscriber/OtelLoggerFlushSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\EventSubscriber;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\SDK\Logs\LoggerProviderInterface as SdkLoggerProviderInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Flushes the OTel LoggerProvider on request and command termination.
+ *
+ * Without this, log records queued inside a BatchLogRecordProcessor can be lost
+ * when a short-lived request or command exits before the processor's scheduled
+ * flush (default 1s) fires.
+ */
+final class OtelLoggerFlushSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array<string, array{0: string, 1: int}|list<array{0: string, 1: int}>>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        $events = [
+            KernelEvents::TERMINATE => ['flush', -1024],
+        ];
+
+        if (class_exists(ConsoleEvents::class)) {
+            $events[ConsoleEvents::TERMINATE] = ['flush', -1024];
+        }
+
+        return $events;
+    }
+
+    public function flush(TerminateEvent|ConsoleTerminateEvent $event): void
+    {
+        try {
+            $provider = Globals::loggerProvider();
+            if ($provider instanceof SdkLoggerProviderInterface) {
+                $provider->forceFlush();
+            }
+        } catch (\Throwable $e) {
+            error_log(sprintf('OtelLoggerFlushSubscriber: forceFlush failed: %s', $e->getMessage()));
+        }
+    }
+}

--- a/src/Monolog/OtelLogHandler.php
+++ b/src/Monolog/OtelLogHandler.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Monolog;
+
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\LoggerInterface;
+use OpenTelemetry\API\Logs\Severity;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Monolog handler that exports log records via the OpenTelemetry Logs API.
+ *
+ * Each Monolog channel becomes its own OTel instrumentation scope, matching
+ * how the official opentelemetry-logger-monolog contrib handler does it.
+ * Trace context is correlated by the SDK from the active span on emit.
+ */
+final class OtelLogHandler extends AbstractProcessingHandler implements ResetInterface
+{
+    /** @var array<string, LoggerInterface> */
+    private array $loggers = [];
+    private readonly NormalizerFormatter $normalizer;
+
+    /**
+     * Guards against recursion when the OTel export path itself produces a log record
+     * (e.g. the OTLP HTTP exporter logging on a failed send). Without this, SimpleLogRecordProcessor
+     * turns such a log into an infinite loop, and BatchLogRecordProcessor's forceFlush loses records.
+     */
+    private bool $emitting = false;
+
+    public function __construct(
+        int|string|Level $level = Level::Debug,
+        bool $bubble = true,
+    ) {
+        parent::__construct($level, $bubble);
+        $this->normalizer = new NormalizerFormatter();
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        if ($this->emitting) {
+            return;
+        }
+
+        $this->emitting = true;
+        try {
+            $builder = $this->getLogger($record->channel)
+                ->logRecordBuilder()
+                ->setTimestamp(((int) $record->datetime->format('Uu')) * 1000)
+                ->setSeverityNumber(Severity::fromPsr3($record->level->toPsrLogLevel()))
+                ->setSeverityText($record->level->getName())
+                ->setBody($record->message)
+                ->setAttribute('monolog.channel', $record->channel);
+
+            foreach ($record->context as $key => $value) {
+                if ('exception' === $key && $value instanceof \Throwable) {
+                    $builder->setException($value);
+                    continue;
+                }
+                $builder->setAttribute('monolog.context.' . $key, $this->toAttributeValue($value));
+            }
+
+            foreach ($record->extra as $key => $value) {
+                // The SDK sets trace_id/span_id natively on the LogRecord from the active span.
+                // TraceContextProcessor also writes them into extra for non-OTel handlers — skip the duplicate here.
+                if ('trace_id' === $key || 'span_id' === $key) {
+                    continue;
+                }
+                $builder->setAttribute('monolog.extra.' . $key, $this->toAttributeValue($value));
+            }
+
+            $builder->emit();
+        } catch (\Throwable $e) {
+            // A logging handler must never take down the thing being logged about.
+            error_log(sprintf('OtelLogHandler: failed to export log record: %s', $e->getMessage()));
+        } finally {
+            $this->emitting = false;
+        }
+    }
+
+    public function reset(): void
+    {
+        parent::reset();
+        $this->loggers = [];
+        $this->emitting = false;
+    }
+
+    private function getLogger(string $channel): LoggerInterface
+    {
+        return $this->loggers[$channel] ??= Globals::loggerProvider()->getLogger($channel);
+    }
+
+    /**
+     * @return bool|int|float|string|array<int, bool|int|float|string|null>|null
+     */
+    private function toAttributeValue(mixed $value): bool|int|float|string|array|null
+    {
+        if (null === $value || \is_scalar($value)) {
+            return $value;
+        }
+
+        $normalized = $this->normalizer->normalizeValue($value);
+
+        if (null === $normalized || \is_scalar($normalized)) {
+            return $normalized;
+        }
+
+        if (array_is_list($normalized)) {
+            $scalarList = [];
+            foreach ($normalized as $item) {
+                if (null !== $item && !\is_scalar($item)) {
+                    $scalarList = null;
+                    break;
+                }
+                $scalarList[] = $item;
+            }
+            if (null !== $scalarList) {
+                return $scalarList;
+            }
+        }
+
+        return json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR) ?: '[unserializable]';
+    }
+}

--- a/tests/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -293,6 +293,19 @@ final class OpenTelemetryExtensionTest extends TestCase
         self::assertFalse($container->hasDefinition(TraceContextProcessor::class));
     }
 
+    public function testLogExportEnabledThrowsWhenMonologBundleMissing(): void
+    {
+        $container = new ContainerBuilder();
+        $extension = new OpenTelemetryExtension();
+        $container->registerExtension($extension);
+        $container->loadFromExtension('open_telemetry', ['log_export_enabled' => true]);
+
+        self::expectException(\LogicException::class);
+        self::expectExceptionMessage('symfony/monolog-bundle');
+
+        $extension->prepend($container);
+    }
+
     private function buildContainer(array $config): ContainerBuilder
     {
         $container = new ContainerBuilder();

--- a/tests/EventSubscriber/OtelLoggerFlushSubscriberTest.php
+++ b/tests/EventSubscriber/OtelLoggerFlushSubscriberTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Traceway\OpenTelemetryBundle\EventSubscriber\OtelLoggerFlushSubscriber;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+final class OtelLoggerFlushSubscriberTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownOTel();
+    }
+
+    public function testSubscribesToKernelAndConsoleTerminate(): void
+    {
+        $events = OtelLoggerFlushSubscriber::getSubscribedEvents();
+
+        self::assertArrayHasKey(KernelEvents::TERMINATE, $events);
+        self::assertArrayHasKey(ConsoleEvents::TERMINATE, $events);
+
+        self::assertSame('flush', $events[KernelEvents::TERMINATE][0]);
+        self::assertSame('flush', $events[ConsoleEvents::TERMINATE][0]);
+    }
+
+    public function testFlushDoesNotThrowOnKernelTerminate(): void
+    {
+        $subscriber = new OtelLoggerFlushSubscriber();
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $event = new TerminateEvent($kernel, new Request(), new Response());
+
+        $subscriber->flush($event);
+
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/tests/Monolog/OtelLogHandlerTest.php
+++ b/tests/Monolog/OtelLogHandlerTest.php
@@ -1,0 +1,397 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Monolog;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\Severity;
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\SDK\Logs\ReadableLogRecord;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Monolog\OtelLogHandler;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+final class OtelLogHandlerTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        if (!class_exists(\Monolog\Logger::class)) {
+            self::markTestSkipped('Monolog not available.');
+        }
+
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownOTel();
+    }
+
+    public function testExportsLogWithCorrectBodyAndSeverity(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Warning,
+            message: 'Something went wrong',
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        self::assertCount(1, $logs);
+
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        self::assertSame('Something went wrong', $log->getBody());
+        self::assertSame(Severity::WARN->value, $log->getSeverityNumber());
+        self::assertSame('WARNING', $log->getSeverityText());
+    }
+
+    public function testExportsLogWithTimestamp(): void
+    {
+        $handler = new OtelLogHandler();
+        $datetime = new \DateTimeImmutable('2026-04-10 12:00:00.123456');
+
+        $record = new LogRecord(
+            datetime: $datetime,
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $expectedNanos = ((int) $datetime->format('Uu')) * 1000;
+        self::assertSame($expectedNanos, $log->getTimestamp());
+    }
+
+    public function testTraceCorrelationWhenSpanIsActive(): void
+    {
+        $tracer = Globals::tracerProvider()->getTracer('test');
+        $span = $tracer->spanBuilder('test-span')->startSpan();
+        $scope = $span->activate();
+
+        try {
+            $handler = new OtelLogHandler();
+            $record = new LogRecord(
+                datetime: new \DateTimeImmutable(),
+                channel: 'app',
+                level: Level::Info,
+                message: 'inside span',
+            );
+            $handler->handle($record);
+        } finally {
+            $scope->detach();
+            $span->end();
+        }
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+
+        $spanContext = $log->getSpanContext();
+        self::assertNotNull($spanContext);
+        self::assertNotSame(SpanContext::getInvalid()->getTraceId(), $spanContext->getTraceId());
+        self::assertNotSame(SpanContext::getInvalid()->getSpanId(), $spanContext->getSpanId());
+    }
+
+    public function testForwardsScalarContextAsAttributes(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            context: ['user_id' => 42, 'action' => 'login'],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertSame(42, $attrs['monolog.context.user_id']);
+        self::assertSame('login', $attrs['monolog.context.action']);
+    }
+
+    public function testForwardsListOfScalarsAsArrayAttribute(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            context: ['tags' => ['alpha', 'beta', 'gamma']],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertSame(['alpha', 'beta', 'gamma'], $attrs['monolog.context.tags']);
+    }
+
+    public function testJsonEncodesNonScalarContextValue(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            context: ['user' => ['id' => 42, 'name' => 'alice']],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertIsString($attrs['monolog.context.user']);
+        self::assertSame(['id' => 42, 'name' => 'alice'], json_decode($attrs['monolog.context.user'], true));
+    }
+
+    public function testSkipsTraceIdAndSpanIdInExtra(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            extra: [
+                'trace_id' => 'deadbeef',
+                'span_id'  => 'cafef00d',
+                'request_id' => 'abc-123',
+            ],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertArrayNotHasKey('monolog.extra.trace_id', $attrs);
+        self::assertArrayNotHasKey('monolog.extra.span_id', $attrs);
+        self::assertSame('abc-123', $attrs['monolog.extra.request_id']);
+    }
+
+    public function testExceptionInContextSetsExceptionAttributes(): void
+    {
+        $handler = new OtelLogHandler();
+        $exception = new \RuntimeException('Something broke');
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Error,
+            message: 'Uncaught exception',
+            context: ['exception' => $exception, 'code' => 500],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertSame(\RuntimeException::class, $attrs['exception.type']);
+        self::assertSame('Something broke', $attrs['exception.message']);
+        self::assertArrayHasKey('exception.stacktrace', $attrs);
+        self::assertSame(500, $attrs['monolog.context.code']);
+        self::assertArrayNotHasKey('monolog.context.exception', $attrs);
+    }
+
+    public function testForwardsScalarExtraAsAttributes(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            extra: ['request_id' => 'abc-123'],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertSame('abc-123', $attrs['monolog.extra.request_id']);
+    }
+
+    public function testSetsChannelAttribute(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'security',
+            level: Level::Info,
+            message: 'test',
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        self::assertSame('security', $log->getAttributes()->toArray()['monolog.channel']);
+    }
+
+    public function testRespectsLevelFilter(): void
+    {
+        $handler = new OtelLogHandler(Level::Error);
+
+        $debugRecord = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Debug,
+            message: 'debug message',
+        );
+
+        $errorRecord = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Error,
+            message: 'error message',
+        );
+
+        $handler->handle($debugRecord);
+        $handler->handle($errorRecord);
+
+        $logs = $this->logExporter->getStorage();
+        self::assertCount(1, $logs);
+
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        self::assertSame('error message', $log->getBody());
+    }
+
+    public function testEachChannelBecomesAnInstrumentationScope(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $handler->handle(new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'from app',
+        ));
+        $handler->handle(new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'security',
+            level: Level::Info,
+            message: 'from security',
+        ));
+
+        $logs = $this->logExporter->getStorage();
+        self::assertCount(2, $logs);
+
+        /** @var ReadableLogRecord $appLog */
+        $appLog = $logs[0];
+        /** @var ReadableLogRecord $securityLog */
+        $securityLog = $logs[1];
+
+        self::assertSame('app', $appLog->getInstrumentationScope()->getName());
+        self::assertSame('security', $securityLog->getInstrumentationScope()->getName());
+    }
+
+    public function testTimestampPreservesMicrosecondPrecision(): void
+    {
+        $handler = new OtelLogHandler();
+        $datetime = new \DateTimeImmutable('2026-04-11 13:55:56.890028');
+
+        $handler->handle(new LogRecord(
+            datetime: $datetime,
+            channel: 'app',
+            level: Level::Info,
+            message: 'precision test',
+        ));
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+
+        $expectedNanos = ((int) $datetime->format('Uu')) * 1000;
+        self::assertSame($expectedNanos, $log->getTimestamp());
+        self::assertSame(890028000, $expectedNanos % 1_000_000_000);
+    }
+
+    public function testReentranceGuardDropsNestedWrites(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $reflection = new \ReflectionClass($handler);
+        $emitting = $reflection->getProperty('emitting');
+        $emitting->setValue($handler, true);
+
+        $handler->handle(new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'nested write during emit',
+        ));
+
+        self::assertCount(0, $this->logExporter->getStorage());
+        self::assertTrue($emitting->getValue($handler));
+    }
+
+    public function testResetClearsCachedLogger(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'before reset',
+        );
+
+        $handler->handle($record);
+        self::assertCount(1, $this->logExporter->getStorage());
+
+        $handler->reset();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'after reset',
+        );
+
+        $handler->handle($record);
+        self::assertCount(2, $this->logExporter->getStorage());
+    }
+}

--- a/tests/OTelTestTrait.php
+++ b/tests/OTelTestTrait.php
@@ -7,6 +7,9 @@ namespace Traceway\OpenTelemetryBundle\Tests;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter as InMemoryLogExporter;
+use OpenTelemetry\SDK\Logs\LoggerProviderBuilder;
+use OpenTelemetry\SDK\Logs\Processor\SimpleLogRecordProcessor;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
@@ -14,14 +17,22 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
 trait OTelTestTrait
 {
     protected InMemoryExporter $exporter;
+    protected InMemoryLogExporter $logExporter;
 
     protected function setUpOTel(): void
     {
         Globals::reset();
         $this->exporter = new InMemoryExporter();
+        $this->logExporter = new InMemoryLogExporter();
+
         $tracerProvider = new TracerProvider(new SimpleSpanProcessor($this->exporter));
+        $loggerProvider = (new LoggerProviderBuilder())
+            ->addLogRecordProcessor(new SimpleLogRecordProcessor($this->logExporter))
+            ->build();
+
         Globals::registerInitializer(fn (Configurator $configurator) => $configurator
             ->withTracerProvider($tracerProvider)
+            ->withLoggerProvider($loggerProvider)
             ->withPropagator(TraceContextPropagator::getInstance()));
     }
 


### PR DESCRIPTION
Adds a new opt-in pipeline that bridges Monolog log records into the OpenTelemetry Logs API, complementing the existing `TraceContextProcessor` (which only injects `trace_id`/`span_id` into log extras). With
   this feature enabled, logs flow through the OTel SDK's `LoggerProvider` and reach any OTel-compatible logs backend (OTLP, console, custom processors).

  The feature is **off by default** and only activates when both `log_export_enabled: true` is set AND `symfony/monolog-bundle` is installed.

## Backwards compatibility

  **Zero impact on default users.** `log_export_enabled` defaults to `false` and every new code path is gated by it. For any user upgrading without changing config:

  - Container compiles identically,  no new service definitions, no new event subscribers
  - No new Monolog handlers registered
  - The `OtelLogHandler` class file is never even autoloaded (the `Definition` is never constructed, so reflection never fires)
  - Same dependency story as v1.5.0,`monolog/monolog` stays in `suggest`, no new entries in `require`
 ## Configuration example

  ```yaml
  open_telemetry:
      monolog_enabled: true            # inject trace_id/span_id into log records (existing)

      log_export_enabled: true         # NEW — export logs via OTel Logs API
      log_export_level: debug          # NEW — minimum severity filter

  OTEL_LOGS_EXPORTER=otlp              # or `console` for local debugging