### PR TITLE
fix: register OtelLogHandler in prepend() to fix bundle loading order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
         "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
         "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
-        "symfony/monolog-bundle": "^4.0",
+        "symfony/monolog-bundle": "^3.10 || ^4.0",
         "symfony/phpunit-bridge": "^6.4 || ^7.0 || ^8.0",
         "twig/twig": "^3.0 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
         "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
         "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
+        "symfony/monolog-bundle": "^4.0",
         "symfony/phpunit-bridge": "^6.4 || ^7.0 || ^8.0",
         "twig/twig": "^3.0 || ^4.0"
     },

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -147,7 +147,6 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $monologDef->addTag('monolog.processor');
             $container->setDefinition(TraceContextProcessor::class, $monologDef);
         }
-
     }
 
     private function isConsoleAvailable(): bool

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -59,6 +59,15 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
                     ],
                 ],
             ]);
+
+            $handlerDef = new Definition(OtelLogHandler::class);
+            $handlerDef->setArgument('$level', $config['log_export_level']);
+            $handlerDef->setAutoconfigured(true);
+            $container->setDefinition(OtelLogHandler::class, $handlerDef);
+
+            $flushDef = new Definition(OtelLoggerFlushSubscriber::class);
+            $flushDef->setAutoconfigured(true);
+            $container->setDefinition(OtelLoggerFlushSubscriber::class, $flushDef);
         }
     }
 
@@ -139,16 +148,6 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->setDefinition(TraceContextProcessor::class, $monologDef);
         }
 
-        if ($config['log_export_enabled'] && $container->hasExtension('monolog')) {
-            $handlerDef = new Definition(OtelLogHandler::class);
-            $handlerDef->setArgument('$level', $config['log_export_level']);
-            $handlerDef->setAutoconfigured(true);
-            $container->setDefinition(OtelLogHandler::class, $handlerDef);
-
-            $flushDef = new Definition(OtelLoggerFlushSubscriber::class);
-            $flushDef->setAutoconfigured(true);
-            $container->setDefinition(OtelLoggerFlushSubscriber::class, $flushDef);
-        }
     }
 
     private function isConsoleAvailable(): bool

--- a/tests/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -6,12 +6,16 @@ namespace Traceway\OpenTelemetryBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Bundle\MonologBundle\MonologBundle;
 use Traceway\OpenTelemetryBundle\DependencyInjection\OpenTelemetryExtension;
 use Traceway\OpenTelemetryBundle\EventSubscriber\ConsoleSubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetrySubscriber;
+use Traceway\OpenTelemetryBundle\EventSubscriber\OtelLoggerFlushSubscriber;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
 use Traceway\OpenTelemetryBundle\Doctrine\Middleware\TraceableMiddleware as DoctrineTraceableMiddleware;
+use Traceway\OpenTelemetryBundle\Monolog\OtelLogHandler;
 use Traceway\OpenTelemetryBundle\Monolog\TraceContextProcessor;
+use Traceway\OpenTelemetryBundle\OpenTelemetryBundle;
 use Traceway\OpenTelemetryBundle\Tracing;
 use Traceway\OpenTelemetryBundle\TracingInterface;
 use Traceway\OpenTelemetryBundle\Twig\OpenTelemetryTwigExtension;
@@ -291,6 +295,32 @@ final class OpenTelemetryExtensionTest extends TestCase
         $container = $this->buildContainer(['monolog_enabled' => false]);
 
         self::assertFalse($container->hasDefinition(TraceContextProcessor::class));
+    }
+
+    public function testLogExportCompilesWithMonologBundleRegisteredFirst(): void
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new \Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension());
+
+        $extension = new OpenTelemetryExtension();
+        $container->registerExtension($extension);
+        $container->loadFromExtension('open_telemetry', ['log_export_enabled' => true]);
+
+        $extension->prepend($container);
+
+        $monologConfigs = $container->getExtensionConfig('monolog');
+        self::assertNotEmpty($monologConfigs, 'OTel prepend should inject monolog handler config');
+
+        $handlerConfig = $monologConfigs[0]['handlers']['opentelemetry'] ?? null;
+        self::assertNotNull($handlerConfig, 'opentelemetry handler should be prepended');
+        self::assertSame('service', $handlerConfig['type']);
+        self::assertSame(OtelLogHandler::class, $handlerConfig['id']);
+
+        self::assertTrue(
+            $container->hasDefinition(OtelLogHandler::class),
+            'OtelLogHandler service must be registered in prepend() so it exists before MonologBundle compiles',
+        );
+        self::assertTrue($container->hasDefinition(OtelLoggerFlushSubscriber::class));
     }
 
     public function testLogExportEnabledThrowsWhenMonologBundleMissing(): void


### PR DESCRIPTION
Move OtelLogHandler and OtelLoggerFlushSubscriber service definitions from load() to prepend(), right after the monolog handler config is prepended.

This ensures the services exist before MonologBundle::load() compiles its handler references, regardless of bundle registration order in bundles.php.

Fixes tracewayapp/opentelemetry-symfony-bundle#17