### PR TITLE
fix: align db and cache spans with OTel semconv (#16)

### DIFF
--- a/src/Cache/TraceableCachePool.php
+++ b/src/Cache/TraceableCachePool.php
@@ -61,7 +61,7 @@ class TraceableCachePool implements CacheInterface, AdapterInterface, ResetInter
         };
 
         $span = $this->getTracer()
-            ->spanBuilder(\sprintf('cache.get %s', $key))
+            ->spanBuilder('cache.get')
             ->setSpanKind(SpanKind::KIND_INTERNAL)
             ->setAttribute('cache.key', $key)
             ->setAttribute('cache.pool', $this->poolName)
@@ -93,7 +93,7 @@ class TraceableCachePool implements CacheInterface, AdapterInterface, ResetInter
         }
 
         $span = $this->getTracer()
-            ->spanBuilder(\sprintf('cache.delete %s', $key))
+            ->spanBuilder('cache.delete')
             ->setSpanKind(SpanKind::KIND_INTERNAL)
             ->setAttribute('cache.key', $key)
             ->setAttribute('cache.pool', $this->poolName)

--- a/src/Doctrine/Middleware/DbSpanBuilder.php
+++ b/src/Doctrine/Middleware/DbSpanBuilder.php
@@ -25,13 +25,20 @@ final class DbSpanBuilder
         ?int $serverPort,
     ): SpanBuilderInterface {
         $operation = SqlOperationExtractor::extract($sql);
+        $target = SqlOperationExtractor::extractTarget($sql);
+        $spanName = SqlOperationExtractor::spanName($operation, $target, $dbName);
 
-        $builder = $tracer->spanBuilder(SqlOperationExtractor::operationSpanName($operation, $dbName))
+        $builder = $tracer->spanBuilder($spanName)
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setAttribute(DbAttributes::DB_SYSTEM_NAME, $dbSystem)
             ->setAttribute('db.system', $dbSystem)
             ->setAttribute(DbAttributes::DB_OPERATION_NAME, $operation)
-            ->setAttribute('db.operation', $operation);
+            ->setAttribute('db.operation', $operation)
+            ->setAttribute(DbAttributes::DB_QUERY_SUMMARY, $spanName);
+
+        if ($target !== null) {
+            $builder->setAttribute(DbAttributes::DB_COLLECTION_NAME, $target);
+        }
 
         if ($dbName !== null) {
             $builder->setAttribute(DbAttributes::DB_NAMESPACE, $dbName);

--- a/src/Doctrine/Middleware/DbSpanBuilder.php
+++ b/src/Doctrine/Middleware/DbSpanBuilder.php
@@ -26,11 +26,7 @@ final class DbSpanBuilder
     ): SpanBuilderInterface {
         $operation = SqlOperationExtractor::extract($sql);
 
-        $spanName = $recordStatements
-            ? SqlOperationExtractor::spanName($sql)
-            : SqlOperationExtractor::operationSpanName($operation, $dbName);
-
-        $builder = $tracer->spanBuilder($spanName)
+        $builder = $tracer->spanBuilder(SqlOperationExtractor::operationSpanName($operation, $dbName))
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setAttribute(DbAttributes::DB_SYSTEM_NAME, $dbSystem)
             ->setAttribute('db.system', $dbSystem)

--- a/src/Doctrine/Middleware/SqlOperationExtractor.php
+++ b/src/Doctrine/Middleware/SqlOperationExtractor.php
@@ -9,6 +9,8 @@ namespace Traceway\OpenTelemetryBundle\Doctrine\Middleware;
  */
 final class SqlOperationExtractor
 {
+    private const IDENT = '(?:[A-Za-z_][A-Za-z0-9_$.]*|`[^`]+`|"[^"]+"|\[[^\]]+\])';
+
     /**
      * @return non-empty-string
      */
@@ -23,14 +25,64 @@ final class SqlOperationExtractor
     }
 
     /**
-     * Builds a concise span name from the operation and optional db name.
+     * Extracts the primary table/collection name from a SQL statement.
+     *
+     * Returns null when the target can't be confidently determined (DDL,
+     * transaction control, multi-table updates, subquery-heavy SELECTs).
+     * The fallback is a low-cardinality operation-only span name, which is
+     * still spec-compliant per OTel database semconv.
+     */
+    public static function extractTarget(string $sql): ?string
+    {
+        $sql = ltrim($sql);
+        if ($sql === '') {
+            return null;
+        }
+
+        $patterns = [
+            '/^INSERT\s+(?:OR\s+\w+\s+)?INTO\s+(' . self::IDENT . ')/i',
+            '/^UPDATE\s+(?:OR\s+\w+\s+)?(' . self::IDENT . ')\s+SET\b/i',
+            '/^DELETE\s+FROM\s+(' . self::IDENT . ')/i',
+            '/^SELECT\b.*?\bFROM\s+(' . self::IDENT . ')/is',
+            '/^REPLACE\s+INTO\s+(' . self::IDENT . ')/i',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $sql, $m)) {
+                return self::stripQuotes($m[1]);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Builds a low-cardinality span name following OTel database semconv:
+     * `{operation} {target}` when the table is known, otherwise
+     * `{operation} {db.namespace}` as a fallback, otherwise just `{operation}`.
      *
      * @param non-empty-string $operation
      *
      * @return non-empty-string
      */
-    public static function operationSpanName(string $operation, ?string $dbName): string
+    public static function spanName(string $operation, ?string $target, ?string $dbName): string
     {
-        return $dbName !== null ? $operation . ' ' . $dbName : $operation;
+        $suffix = $target ?? $dbName;
+
+        return $suffix !== null ? $operation . ' ' . $suffix : $operation;
+    }
+
+    private static function stripQuotes(string $ident): string
+    {
+        if ($ident === '') {
+            return $ident;
+        }
+
+        $first = $ident[0];
+        if ($first === '`' || $first === '"' || $first === '[') {
+            return substr($ident, 1, -1);
+        }
+
+        return $ident;
     }
 }

--- a/src/Doctrine/Middleware/SqlOperationExtractor.php
+++ b/src/Doctrine/Middleware/SqlOperationExtractor.php
@@ -23,25 +23,6 @@ final class SqlOperationExtractor
     }
 
     /**
-     * Truncates SQL to a reasonable span-name length.
-     *
-     * @return non-empty-string
-     */
-    public static function spanName(string $sql): string
-    {
-        $sql = ltrim($sql);
-        if ($sql === '') {
-            return 'SQL';
-        }
-
-        if (mb_strlen($sql, 'UTF-8') > 120) {
-            return mb_substr($sql, 0, 117, 'UTF-8') . '...';
-        }
-
-        return $sql;
-    }
-
-    /**
      * Builds a concise span name from the operation and optional db name.
      *
      * @param non-empty-string $operation

--- a/src/Doctrine/Middleware/TraceableConnectionDbal3.php
+++ b/src/Doctrine/Middleware/TraceableConnectionDbal3.php
@@ -12,6 +12,7 @@ use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 
 final class TraceableConnectionDbal3 extends AbstractConnectionMiddleware
 {
@@ -57,6 +58,7 @@ final class TraceableConnectionDbal3 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -79,6 +81,7 @@ final class TraceableConnectionDbal3 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -103,6 +106,7 @@ final class TraceableConnectionDbal3 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -127,6 +131,7 @@ final class TraceableConnectionDbal3 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -151,6 +156,7 @@ final class TraceableConnectionDbal3 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {

--- a/src/Doctrine/Middleware/TraceableConnectionDbal4.php
+++ b/src/Doctrine/Middleware/TraceableConnectionDbal4.php
@@ -12,6 +12,7 @@ use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 
 final class TraceableConnectionDbal4 extends AbstractConnectionMiddleware
 {
@@ -57,6 +58,7 @@ final class TraceableConnectionDbal4 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -79,6 +81,7 @@ final class TraceableConnectionDbal4 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -103,6 +106,7 @@ final class TraceableConnectionDbal4 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -125,6 +129,7 @@ final class TraceableConnectionDbal4 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {
@@ -147,6 +152,7 @@ final class TraceableConnectionDbal4 extends AbstractConnectionMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {

--- a/src/Doctrine/Middleware/TraceableStatementDbal3.php
+++ b/src/Doctrine/Middleware/TraceableStatementDbal3.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\Statement;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 
 final class TraceableStatementDbal3 extends AbstractStatementMiddleware
 {
@@ -53,6 +54,7 @@ final class TraceableStatementDbal3 extends AbstractStatementMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {

--- a/src/Doctrine/Middleware/TraceableStatementDbal4.php
+++ b/src/Doctrine/Middleware/TraceableStatementDbal4.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\Statement;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 
 final class TraceableStatementDbal4 extends AbstractStatementMiddleware
 {
@@ -50,6 +51,7 @@ final class TraceableStatementDbal4 extends AbstractStatementMiddleware
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+            $span->setAttribute(ErrorAttributes::ERROR_TYPE, $e::class);
 
             throw $e;
         } finally {

--- a/tests/Cache/TraceableCachePoolTest.php
+++ b/tests/Cache/TraceableCachePoolTest.php
@@ -41,7 +41,7 @@ final class TraceableCachePoolTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('cache.get my_key', $spans[0]->getName());
+        self::assertSame('cache.get', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_INTERNAL, $spans[0]->getKind());
 
         $attrs = $spans[0]->getAttributes()->toArray();
@@ -99,7 +99,7 @@ final class TraceableCachePoolTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('cache.delete old_key', $spans[0]->getName());
+        self::assertSame('cache.delete', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_INTERNAL, $spans[0]->getKind());
 
         $attrs = $spans[0]->getAttributes()->toArray();
@@ -120,7 +120,7 @@ final class TraceableCachePoolTest extends TestCase
         } finally {
             $spans = $this->exporter->getSpans();
             self::assertCount(1, $spans);
-            self::assertSame('cache.delete key', $spans[0]->getName());
+            self::assertSame('cache.delete', $spans[0]->getName());
             self::assertSame(StatusCode::STATUS_ERROR, $spans[0]->getStatus()->getCode());
             self::assertSame('Delete failed', $spans[0]->getStatus()->getDescription());
 

--- a/tests/Cache/TraceableNamespacedCachePoolTest.php
+++ b/tests/Cache/TraceableNamespacedCachePoolTest.php
@@ -55,7 +55,7 @@ final class TraceableNamespacedCachePoolTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('cache.get key', $spans[0]->getName());
+        self::assertSame('cache.get', $spans[0]->getName());
     }
 
     public function testConstructorRejectsNonNamespacedPool(): void

--- a/tests/Cache/TraceableTagAwareCachePoolTest.php
+++ b/tests/Cache/TraceableTagAwareCachePoolTest.php
@@ -106,8 +106,8 @@ final class TraceableTagAwareCachePoolTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(2, $spans);
-        self::assertSame('cache.get key', $spans[0]->getName());
-        self::assertSame('cache.delete key', $spans[1]->getName());
+        self::assertSame('cache.get', $spans[0]->getName());
+        self::assertSame('cache.delete', $spans[1]->getName());
     }
 
     private function createTagAwarePool(): AdapterInterface&TagAwareCacheInterface

--- a/tests/Doctrine/Middleware/DbSpanBuilderTest.php
+++ b/tests/Doctrine/Middleware/DbSpanBuilderTest.php
@@ -42,7 +42,7 @@ final class DbSpanBuilderTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT my_db', $spans[0]->getName());
+        self::assertSame('SELECT users', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attrs = $spans[0]->getAttributes()->toArray();
@@ -50,6 +50,8 @@ final class DbSpanBuilderTest extends TestCase
         self::assertSame('postgresql', $attrs['db.system']);
         self::assertSame('SELECT', $attrs['db.operation.name']);
         self::assertSame('SELECT', $attrs['db.operation']);
+        self::assertSame('SELECT users', $attrs['db.query.summary']);
+        self::assertSame('users', $attrs['db.collection.name']);
         self::assertSame('my_db', $attrs['db.namespace']);
         self::assertSame('my_db', $attrs['db.name']);
         self::assertSame('SELECT * FROM users WHERE id = ?', $attrs['db.query.text']);
@@ -75,9 +77,10 @@ final class DbSpanBuilderTest extends TestCase
         $span->end();
 
         $spans = $this->exporter->getSpans();
-        self::assertSame('DELETE app_db', $spans[0]->getName());
+        self::assertSame('DELETE sessions', $spans[0]->getName());
 
         $attrs = $spans[0]->getAttributes()->toArray();
+        self::assertSame('sessions', $attrs['db.collection.name']);
         self::assertArrayNotHasKey('db.query.text', $attrs);
         self::assertArrayNotHasKey('db.statement', $attrs);
     }
@@ -103,6 +106,7 @@ final class DbSpanBuilderTest extends TestCase
 
         $attrs = $spans[0]->getAttributes()->toArray();
         self::assertSame('sqlite', $attrs['db.system.name']);
+        self::assertArrayNotHasKey('db.collection.name', $attrs);
         self::assertArrayNotHasKey('db.namespace', $attrs);
         self::assertArrayNotHasKey('db.name', $attrs);
         self::assertArrayNotHasKey('server.address', $attrs);

--- a/tests/Doctrine/Middleware/DbSpanBuilderTest.php
+++ b/tests/Doctrine/Middleware/DbSpanBuilderTest.php
@@ -42,7 +42,7 @@ final class DbSpanBuilderTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT * FROM users WHERE id = ?', $spans[0]->getName());
+        self::assertSame('SELECT my_db', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attrs = $spans[0]->getAttributes()->toArray();

--- a/tests/Doctrine/Middleware/SqlOperationExtractorTest.php
+++ b/tests/Doctrine/Middleware/SqlOperationExtractorTest.php
@@ -37,20 +37,78 @@ final class SqlOperationExtractorTest extends TestCase
         yield 'whitespace only' => ['   ', 'UNKNOWN'];
     }
 
-    #[DataProvider('operationSpanNameProvider')]
-    public function testOperationSpanName(string $operation, ?string $dbName, string $expected): void
+    #[DataProvider('extractTargetProvider')]
+    public function testExtractTarget(string $sql, ?string $expected): void
     {
-        self::assertSame($expected, SqlOperationExtractor::operationSpanName($operation, $dbName));
+        self::assertSame($expected, SqlOperationExtractor::extractTarget($sql));
     }
 
     /**
-     * @return iterable<string, array{string, ?string, string}>
+     * @return iterable<string, array{string, ?string}>
      */
-    public static function operationSpanNameProvider(): iterable
+    public static function extractTargetProvider(): iterable
     {
-        yield 'with db name' => ['SELECT', 'my_db', 'SELECT my_db'];
-        yield 'without db name' => ['INSERT', null, 'INSERT'];
-        yield 'begin with db' => ['BEGIN', 'app', 'BEGIN app'];
-        yield 'commit without db' => ['COMMIT', null, 'COMMIT'];
+        // INSERT
+        yield 'insert simple' => ['INSERT INTO items (name) VALUES (?)', 'items'];
+        yield 'insert lowercase' => ['insert into items values (?)', 'items'];
+        yield 'insert qualified' => ['INSERT INTO public.items (name) VALUES (?)', 'public.items'];
+        yield 'insert backticked' => ['INSERT INTO `items` VALUES (?)', 'items'];
+        yield 'insert double-quoted' => ['INSERT INTO "items" VALUES (?)', 'items'];
+        yield 'insert sqlite OR REPLACE' => ['INSERT OR REPLACE INTO items VALUES (?)', 'items'];
+
+        // UPDATE
+        yield 'update simple' => ['UPDATE items SET price = ?', 'items'];
+        yield 'update lowercase' => ['update items set price = ?', 'items'];
+        yield 'update qualified' => ['UPDATE public.items SET price = ?', 'public.items'];
+        yield 'update backticked' => ['UPDATE `items` SET price = ?', 'items'];
+        yield 'update sqlite OR FAIL' => ['UPDATE OR FAIL items SET price = ?', 'items'];
+        yield 'update with alias (no target)' => ['UPDATE items i SET price = ?', null];
+
+        // DELETE
+        yield 'delete simple' => ['DELETE FROM items WHERE id = ?', 'items'];
+        yield 'delete lowercase' => ['delete from items', 'items'];
+        yield 'delete qualified' => ['DELETE FROM public.items', 'public.items'];
+        yield 'delete bracketed' => ['DELETE FROM [items] WHERE id = 1', 'items'];
+
+        // SELECT
+        yield 'select star' => ['SELECT * FROM items', 'items'];
+        yield 'select with where' => ['SELECT id FROM items WHERE name = ?', 'items'];
+        yield 'select with join' => ['SELECT * FROM items JOIN orders ON items.id = orders.item_id', 'items'];
+        yield 'select with alias' => ['SELECT u.name FROM users u WHERE u.id = ?', 'users'];
+        yield 'select count' => ['SELECT COUNT(*) FROM items', 'items'];
+        yield 'select multiline' => ["SELECT *\n  FROM items\n  WHERE id = ?", 'items'];
+        yield 'select qualified' => ['SELECT * FROM public.items', 'public.items'];
+
+        // REPLACE (MySQL/SQLite)
+        yield 'replace into' => ['REPLACE INTO items VALUES (?)', 'items'];
+
+        // No target / unsupported
+        yield 'begin' => ['BEGIN', null];
+        yield 'commit' => ['COMMIT', null];
+        yield 'rollback' => ['ROLLBACK', null];
+        yield 'create table' => ['CREATE TABLE items (id INT)', null];
+        // Subquery in FROM: regex backtracks past the outer `(` to find the
+        // first FROM followed by a valid identifier, which is the inner table.
+        // Acceptable for span-naming since cardinality is still bounded.
+        yield 'select subquery captures inner table' => ['SELECT * FROM (SELECT id FROM users) sub', 'users'];
+        yield 'empty' => ['', null];
+        yield 'unknown' => ['EXPLAIN ANALYZE SELECT 1', null];
+    }
+
+    #[DataProvider('spanNameProvider')]
+    public function testSpanName(string $operation, ?string $target, ?string $dbName, string $expected): void
+    {
+        self::assertSame($expected, SqlOperationExtractor::spanName($operation, $target, $dbName));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, ?string, string}>
+     */
+    public static function spanNameProvider(): iterable
+    {
+        yield 'target wins over db' => ['SELECT', 'items', 'my_db', 'SELECT items'];
+        yield 'target only' => ['INSERT', 'items', null, 'INSERT items'];
+        yield 'db only' => ['SELECT', null, 'my_db', 'SELECT my_db'];
+        yield 'neither' => ['BEGIN', null, null, 'BEGIN'];
     }
 }

--- a/tests/Doctrine/Middleware/SqlOperationExtractorTest.php
+++ b/tests/Doctrine/Middleware/SqlOperationExtractorTest.php
@@ -37,37 +37,6 @@ final class SqlOperationExtractorTest extends TestCase
         yield 'whitespace only' => ['   ', 'UNKNOWN'];
     }
 
-    #[DataProvider('spanNameProvider')]
-    public function testSpanName(string $sql, string $expected): void
-    {
-        self::assertSame($expected, SqlOperationExtractor::spanName($sql));
-    }
-
-    /**
-     * @return iterable<string, array{string, string}>
-     */
-    public static function spanNameProvider(): iterable
-    {
-        yield 'short sql' => ['SELECT * FROM users', 'SELECT * FROM users'];
-        yield 'exact 120 chars' => [str_repeat('x', 120), str_repeat('x', 120)];
-        yield 'over 120 chars' => [str_repeat('x', 121), str_repeat('x', 117) . '...'];
-        yield 'way over 120' => [str_repeat('A', 300), str_repeat('A', 117) . '...'];
-        yield 'empty string' => ['', 'SQL'];
-        yield 'whitespace only' => ['   ', 'SQL'];
-        yield 'leading whitespace preserved' => ['  SELECT 1', 'SELECT 1'];
-    }
-
-    public function testSpanNameWithMultibyteCharacters(): void
-    {
-        $sql = 'SELECT * FROM données WHERE clé = ?';
-        self::assertSame($sql, SqlOperationExtractor::spanName($sql));
-
-        $longUtf8 = 'SELECT ' . str_repeat('é', 120);
-        $result = SqlOperationExtractor::spanName($longUtf8);
-        self::assertStringEndsWith('...', $result);
-        self::assertTrue(mb_check_encoding($result, 'UTF-8'));
-    }
-
     #[DataProvider('operationSpanNameProvider')]
     public function testOperationSpanName(string $operation, ?string $dbName, string $expected): void
     {

--- a/tests/Doctrine/Middleware/TraceableConnectionDbal3Test.php
+++ b/tests/Doctrine/Middleware/TraceableConnectionDbal3Test.php
@@ -67,7 +67,7 @@ final class TraceableConnectionDbal3Test extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('INSERT app_db', $spans[0]->getName());
+        self::assertSame('INSERT users', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attributes = $spans[0]->getAttributes()->toArray();
@@ -86,7 +86,7 @@ final class TraceableConnectionDbal3Test extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT app_db', $spans[0]->getName());
+        self::assertSame('SELECT users', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
     }
 

--- a/tests/Doctrine/Middleware/TraceableConnectionTest.php
+++ b/tests/Doctrine/Middleware/TraceableConnectionTest.php
@@ -64,7 +64,7 @@ final class TraceableConnectionTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('INSERT app_db', $spans[0]->getName());
+        self::assertSame('INSERT users', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attributes = $spans[0]->getAttributes()->toArray();
@@ -72,6 +72,7 @@ final class TraceableConnectionTest extends TestCase
         self::assertSame('mysql', $attributes['db.system']);
         self::assertSame('INSERT', $attributes['db.operation.name']);
         self::assertSame('INSERT', $attributes['db.operation']);
+        self::assertSame('users', $attributes['db.collection.name']);
         self::assertSame('app_db', $attributes['db.namespace']);
         self::assertSame('app_db', $attributes['db.name']);
         self::assertSame('localhost', $attributes['server.address']);
@@ -88,7 +89,7 @@ final class TraceableConnectionTest extends TestCase
         $connection->exec('INSERT INTO users (name) VALUES ("test")');
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('INSERT app_db', $span->getName());
+        self::assertSame('INSERT users', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('INSERT INTO users (name) VALUES ("test")', $attr['db.query.text']);
         self::assertSame('INSERT INTO users (name) VALUES ("test")', $attr['db.statement']);
@@ -105,7 +106,7 @@ final class TraceableConnectionTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT app_db', $spans[0]->getName());
+        self::assertSame('SELECT users', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
         self::assertArrayNotHasKey('db.query.text', $spans[0]->getAttributes()->toArray());
         self::assertArrayNotHasKey('db.statement', $spans[0]->getAttributes()->toArray());
@@ -120,7 +121,7 @@ final class TraceableConnectionTest extends TestCase
         $connection->query('SELECT * FROM users WHERE id = 1');
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('SELECT app_db', $span->getName());
+        self::assertSame('SELECT users', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('SELECT * FROM users WHERE id = 1', $attr['db.query.text']);
         self::assertSame('SELECT * FROM users WHERE id = 1', $attr['db.statement']);
@@ -150,6 +151,7 @@ final class TraceableConnectionTest extends TestCase
         self::assertCount(1, $spans);
         self::assertSame(StatusCode::STATUS_ERROR, $spans[0]->getStatus()->getCode());
         self::assertSame('Connection lost', $spans[0]->getStatus()->getDescription());
+        self::assertSame(\RuntimeException::class, $spans[0]->getAttributes()->toArray()['error.type']);
 
         $events = $spans[0]->getEvents();
         self::assertNotEmpty($events);
@@ -167,7 +169,7 @@ final class TraceableConnectionTest extends TestCase
         }
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('SELECT app_db', $span->getName());
+        self::assertSame('SELECT slow_table', $span->getName());
         self::assertArrayNotHasKey('db.query.text', $span->getAttributes()->toArray());
         self::assertArrayNotHasKey('db.statement', $span->getAttributes()->toArray());
     }
@@ -184,7 +186,7 @@ final class TraceableConnectionTest extends TestCase
         }
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('SELECT app_db', $span->getName());
+        self::assertSame('SELECT slow_table', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('SELECT * FROM slow_table', $attr['db.query.text']);
         self::assertSame('SELECT * FROM slow_table', $attr['db.statement']);
@@ -273,7 +275,7 @@ final class TraceableConnectionTest extends TestCase
         $connection->exec($longSql);
 
         $spans = $this->exporter->getSpans();
-        self::assertSame('SELECT app_db', $spans[0]->getName());
+        self::assertSame('SELECT very_long_table_name', $spans[0]->getName());
         self::assertSame($longSql, $spans[0]->getAttributes()->toArray()['db.query.text']);
     }
 

--- a/tests/Doctrine/Middleware/TraceableConnectionTest.php
+++ b/tests/Doctrine/Middleware/TraceableConnectionTest.php
@@ -88,7 +88,7 @@ final class TraceableConnectionTest extends TestCase
         $connection->exec('INSERT INTO users (name) VALUES ("test")');
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('INSERT INTO users (name) VALUES ("test")', $span->getName());
+        self::assertSame('INSERT app_db', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('INSERT INTO users (name) VALUES ("test")', $attr['db.query.text']);
         self::assertSame('INSERT INTO users (name) VALUES ("test")', $attr['db.statement']);
@@ -120,7 +120,7 @@ final class TraceableConnectionTest extends TestCase
         $connection->query('SELECT * FROM users WHERE id = 1');
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('SELECT * FROM users WHERE id = 1', $span->getName());
+        self::assertSame('SELECT app_db', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('SELECT * FROM users WHERE id = 1', $attr['db.query.text']);
         self::assertSame('SELECT * FROM users WHERE id = 1', $attr['db.statement']);
@@ -184,7 +184,7 @@ final class TraceableConnectionTest extends TestCase
         }
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('SELECT * FROM slow_table', $span->getName());
+        self::assertSame('SELECT app_db', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('SELECT * FROM slow_table', $attr['db.query.text']);
         self::assertSame('SELECT * FROM slow_table', $attr['db.statement']);
@@ -206,7 +206,7 @@ final class TraceableConnectionTest extends TestCase
         $connection->beginTransaction();
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('BEGIN', $span->getName());
+        self::assertSame('BEGIN app_db', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('BEGIN', $attr['db.query.text']);
         self::assertSame('BEGIN', $attr['db.statement']);
@@ -228,7 +228,7 @@ final class TraceableConnectionTest extends TestCase
         $connection->commit();
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('COMMIT', $span->getName());
+        self::assertSame('COMMIT app_db', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('COMMIT', $attr['db.query.text']);
         self::assertSame('COMMIT', $attr['db.statement']);
@@ -250,13 +250,13 @@ final class TraceableConnectionTest extends TestCase
         $connection->rollBack();
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('ROLLBACK', $span->getName());
+        self::assertSame('ROLLBACK app_db', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('ROLLBACK', $attr['db.query.text']);
         self::assertSame('ROLLBACK', $attr['db.statement']);
     }
 
-    public function testSpanNameTruncatedForLongSql(): void
+    public function testSpanNameIsLowCardinalityForLongSql(): void
     {
         $connection = new \Traceway\OpenTelemetryBundle\Doctrine\Middleware\TraceableConnectionDbal4(
             $this->inner,
@@ -273,9 +273,8 @@ final class TraceableConnectionTest extends TestCase
         $connection->exec($longSql);
 
         $spans = $this->exporter->getSpans();
-        self::assertSame(120, \strlen($spans[0]->getName()));
-        self::assertStringEndsWith('...', $spans[0]->getName());
-        self::assertStringStartsWith('SELECT id, name, email', $spans[0]->getName());
+        self::assertSame('SELECT app_db', $spans[0]->getName());
+        self::assertSame($longSql, $spans[0]->getAttributes()->toArray()['db.query.text']);
     }
 
     public function testSpanNameWithoutDbName(): void

--- a/tests/Doctrine/Middleware/TraceableStatementDbal3Test.php
+++ b/tests/Doctrine/Middleware/TraceableStatementDbal3Test.php
@@ -63,7 +63,7 @@ final class TraceableStatementDbal3Test extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT my_db', $spans[0]->getName());
+        self::assertSame('SELECT orders', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attributes = $spans[0]->getAttributes()->toArray();
@@ -96,7 +96,7 @@ final class TraceableStatementDbal3Test extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT app', $spans[0]->getName());
+        self::assertSame('SELECT users', $spans[0]->getName());
     }
 
     public function testExecuteRecordsException(): void

--- a/tests/Doctrine/Middleware/TraceableStatementDbal3Test.php
+++ b/tests/Doctrine/Middleware/TraceableStatementDbal3Test.php
@@ -63,7 +63,7 @@ final class TraceableStatementDbal3Test extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT * FROM orders WHERE user_id = ?', $spans[0]->getName());
+        self::assertSame('SELECT my_db', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attributes = $spans[0]->getAttributes()->toArray();
@@ -96,7 +96,7 @@ final class TraceableStatementDbal3Test extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT * FROM users WHERE id = ?', $spans[0]->getName());
+        self::assertSame('SELECT app', $spans[0]->getName());
     }
 
     public function testExecuteRecordsException(): void

--- a/tests/Doctrine/Middleware/TraceableStatementTest.php
+++ b/tests/Doctrine/Middleware/TraceableStatementTest.php
@@ -61,7 +61,7 @@ final class TraceableStatementTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT my_db', $spans[0]->getName());
+        self::assertSame('SELECT orders', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attributes = $spans[0]->getAttributes()->toArray();
@@ -69,6 +69,7 @@ final class TraceableStatementTest extends TestCase
         self::assertSame('postgresql', $attributes['db.system']);
         self::assertSame('SELECT', $attributes['db.operation.name']);
         self::assertSame('SELECT', $attributes['db.operation']);
+        self::assertSame('orders', $attributes['db.collection.name']);
         self::assertSame('my_db', $attributes['db.namespace']);
         self::assertSame('my_db', $attributes['db.name']);
         self::assertSame('SELECT * FROM orders WHERE user_id = ?', $attributes['db.query.text']);
@@ -123,7 +124,7 @@ final class TraceableStatementTest extends TestCase
         $statement->execute();
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('UPDATE app', $span->getName());
+        self::assertSame('UPDATE accounts', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('UPDATE accounts SET balance = ? WHERE id = ?', $attr['db.query.text']);
         self::assertSame('UPDATE accounts SET balance = ? WHERE id = ?', $attr['db.statement']);
@@ -148,7 +149,7 @@ final class TraceableStatementTest extends TestCase
         $statement->execute();
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('SELECT app', $span->getName());
+        self::assertSame('SELECT users', $span->getName());
         self::assertArrayNotHasKey('db.query.text', $span->getAttributes()->toArray());
         self::assertArrayNotHasKey('db.statement', $span->getAttributes()->toArray());
     }
@@ -172,7 +173,7 @@ final class TraceableStatementTest extends TestCase
         $statement->execute();
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('INSERT', $span->getName());
+        self::assertSame('INSERT logs', $span->getName());
         self::assertArrayNotHasKey('db.query.text', $span->getAttributes()->toArray());
         self::assertArrayNotHasKey('db.statement', $span->getAttributes()->toArray());
     }

--- a/tests/Doctrine/Middleware/TraceableStatementTest.php
+++ b/tests/Doctrine/Middleware/TraceableStatementTest.php
@@ -61,7 +61,7 @@ final class TraceableStatementTest extends TestCase
 
         $spans = $this->exporter->getSpans();
         self::assertCount(1, $spans);
-        self::assertSame('SELECT * FROM orders WHERE user_id = ?', $spans[0]->getName());
+        self::assertSame('SELECT my_db', $spans[0]->getName());
         self::assertSame(SpanKind::KIND_CLIENT, $spans[0]->getKind());
 
         $attributes = $spans[0]->getAttributes()->toArray();
@@ -104,7 +104,7 @@ final class TraceableStatementTest extends TestCase
         self::assertSame('Deadlock', $spans[0]->getStatus()->getDescription());
     }
 
-    public function testSpanNameIsSqlWhenRecordStatementsEnabled(): void
+    public function testSpanNameIsLowCardinalityWhenRecordStatementsEnabled(): void
     {
         $inner = $this->createStub(Statement::class);
         $inner->method('execute')->willReturn($this->createStub(Result::class));
@@ -123,7 +123,7 @@ final class TraceableStatementTest extends TestCase
         $statement->execute();
 
         $span = $this->exporter->getSpans()[0];
-        self::assertSame('UPDATE accounts SET balance = ? WHERE id = ?', $span->getName());
+        self::assertSame('UPDATE app', $span->getName());
         $attr = $span->getAttributes()->toArray();
         self::assertSame('UPDATE accounts SET balance = ? WHERE id = ?', $attr['db.query.text']);
         self::assertSame('UPDATE accounts SET balance = ? WHERE id = ?', $attr['db.statement']);


### PR DESCRIPTION
 - Fixes [#16](https://github.com/tracewayapp/opentelemetry-symfony-bundle/issues/16): DB and cache span names are no longer high-cardinality SQL/keys. Span names now follow `{db.operation.name} {target}` per
   the [OTel database semconv](https://opentelemetry.io/docs/specs/semconv/db/database-spans/) (e.g. `SELECT items`); cache spans collapse from `cache.get <key>` to `cache.get`.
  - Adds `db.collection.name`, `db.query.summary`, and `error.type` attributes for full semconv alignment.
  - SQL target is extracted from `INSERT`/`UPDATE`/`DELETE`/`SELECT`/`REPLACE` with support for backtick/double-quote/bracket quoting, schema-qualified names, and sqlite `OR …` modifiers. Falls back to
  operation-only when the target can't be confidently parsed.