### PR TITLE
test: improve coverage with unit and functional tests

### DIFF
--- a/tests/Cache/TraceableCachePoolTest.php
+++ b/tests/Cache/TraceableCachePoolTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Service\ResetInterface;
 use Traceway\OpenTelemetryBundle\Cache\TraceableCachePool;
 use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
 
@@ -187,6 +188,91 @@ final class TraceableCachePoolTest extends TestCase
         $pool->get('key', fn () => 'value');
     }
 
+    public function testDeleteRejectsPoolWithoutCacheInterface(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must implement');
+
+        $inner = $this->createMock(CacheItemPoolInterface::class);
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+        $pool->delete('key');
+    }
+
+    public function testPsr6DelegationMethods(): void
+    {
+        $inner = $this->createCachePool('value', true);
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+
+        self::assertTrue($pool->deleteItems(['a', 'b']));
+        self::assertTrue($pool->commit());
+        self::assertEmpty($pool->getItems(['a']));
+        self::assertEmpty($this->exporter->getSpans());
+    }
+
+    public function testSaveAndSaveDeferredDelegate(): void
+    {
+        $inner = $this->createCachePool('value', true);
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+
+        $item = $this->createStub(CacheItemInterface::class);
+        self::assertTrue($pool->save($item));
+        self::assertTrue($pool->saveDeferred($item));
+        self::assertEmpty($this->exporter->getSpans());
+    }
+
+    public function testResetClearsTracerAndResetsPool(): void
+    {
+        $inner = $this->createResettableCachePool('value', true);
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+
+        $pool->get('key', fn () => 'value');
+        self::assertCount(1, $this->exporter->getSpans());
+
+        $pool->reset();
+
+        $pool->get('key2', fn () => 'value');
+        self::assertCount(2, $this->exporter->getSpans());
+    }
+
+    public function testResetWithNonResettablePool(): void
+    {
+        $inner = $this->createCachePool('value', true);
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+
+        $pool->reset();
+
+        $pool->get('key', fn () => 'value');
+        self::assertCount(1, $this->exporter->getSpans());
+    }
+
+    public function testClearDelegatesToNonAdapterPool(): void
+    {
+        $inner = new class implements CacheItemPoolInterface, CacheInterface {
+            public bool $cleared = false;
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed { return null; }
+            public function delete(string $key): bool { return true; }
+            public function getItem(mixed $key): CacheItem { throw new \LogicException('Not implemented'); }
+            public function getItems(array $keys = []): iterable { return []; }
+            public function hasItem(mixed $key): bool { return false; }
+            public function clear(): bool { $this->cleared = true; return true; }
+            public function deleteItem(string $key): bool { return true; }
+            public function deleteItems(array $keys): bool { return true; }
+            public function save(CacheItemInterface $item): bool { return true; }
+            public function saveDeferred(CacheItemInterface $item): bool { return true; }
+            public function commit(): bool { return true; }
+        };
+
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+        $result = $pool->clear();
+
+        self::assertTrue($result);
+        self::assertTrue($inner->cleared);
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        self::assertSame('cache.clear', $spans[0]->getName());
+    }
+
     public function testCustomTracerName(): void
     {
         $inner = $this->createCachePool('value', true);
@@ -240,6 +326,48 @@ final class TraceableCachePoolTest extends TestCase
             public function save(CacheItemInterface $item): bool { return true; }
             public function saveDeferred(CacheItemInterface $item): bool { return true; }
             public function commit(): bool { return true; }
+        };
+
+        return $mock;
+    }
+
+    private function createResettableCachePool(mixed $returnValue, bool $isHit): AdapterInterface&CacheInterface&ResetInterface
+    {
+        $mock = new class($returnValue, $isHit) implements AdapterInterface, CacheInterface, ResetInterface {
+            public bool $wasReset = false;
+            public function __construct(
+                private readonly mixed $returnValue,
+                private readonly bool $isHit,
+            ) {}
+
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+            {
+                return $this->isHit ? $this->returnValue : $callback(
+                    new class implements ItemInterface {
+                        public function getKey(): string { return ''; }
+                        public function get(): mixed { return null; }
+                        public function isHit(): bool { return false; }
+                        public function set(mixed $value): static { return $this; }
+                        public function expiresAt(?\DateTimeInterface $expiration): static { return $this; }
+                        public function expiresAfter(\DateInterval|int|null $time): static { return $this; }
+                        public function tag(string|iterable $tags): static { return $this; }
+                        public function getMetadata(): array { return []; }
+                    },
+                    $save = true,
+                );
+            }
+
+            public function delete(string $key): bool { return true; }
+            public function getItem(mixed $key): CacheItem { throw new \LogicException('Not implemented'); }
+            public function getItems(array $keys = []): iterable { return []; }
+            public function hasItem(mixed $key): bool { return false; }
+            public function clear(string $prefix = ''): bool { return true; }
+            public function deleteItem(string $key): bool { return true; }
+            public function deleteItems(array $keys): bool { return true; }
+            public function save(CacheItemInterface $item): bool { return true; }
+            public function saveDeferred(CacheItemInterface $item): bool { return true; }
+            public function commit(): bool { return true; }
+            public function reset(): void { $this->wasReset = true; }
         };
 
         return $mock;

--- a/tests/Functional/BundleBootTest.php
+++ b/tests/Functional/BundleBootTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\EventSubscriber\ConsoleSubscriber;
+use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetrySubscriber;
+use Traceway\OpenTelemetryBundle\EventSubscriber\OtelLoggerFlushSubscriber;
+use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
+use Traceway\OpenTelemetryBundle\Monolog\OtelLogHandler;
+use Traceway\OpenTelemetryBundle\Tracing;
+use Traceway\OpenTelemetryBundle\TracingInterface;
+
+final class BundleBootTest extends TestCase
+{
+    private ?OpenTelemetryTestKernel $kernel = null;
+
+    /** @var callable|null */
+    private mixed $previousExceptionHandler = null;
+
+    protected function setUp(): void
+    {
+        $this->previousExceptionHandler = set_exception_handler(null);
+        restore_exception_handler();
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->kernel) {
+            $this->kernel->shutdown();
+            $this->kernel = null;
+        }
+
+        // Restore exception handler to the state before the test
+        set_exception_handler($this->previousExceptionHandler);
+    }
+
+    public function testDefaultConfigBootsSuccessfully(): void
+    {
+        $container = $this->boot();
+
+        self::assertInstanceOf(Tracing::class, $container->get(TracingInterface::class));
+    }
+
+    public function testCoreServicesAreWired(): void
+    {
+        $container = $this->boot();
+
+        self::assertInstanceOf(OpenTelemetrySubscriber::class, $container->get(OpenTelemetrySubscriber::class));
+        self::assertInstanceOf(ConsoleSubscriber::class, $container->get(ConsoleSubscriber::class));
+        self::assertInstanceOf(OpenTelemetryMiddleware::class, $container->get(OpenTelemetryMiddleware::class));
+    }
+
+    public function testTracesDisabledRemovesSubscriber(): void
+    {
+        $container = $this->boot(['traces_enabled' => false]);
+
+        self::assertFalse($container->has(OpenTelemetrySubscriber::class));
+        self::assertInstanceOf(Tracing::class, $container->get(TracingInterface::class));
+    }
+
+    public function testConsoleDisabledRemovesSubscriber(): void
+    {
+        $container = $this->boot(['console_enabled' => false]);
+
+        self::assertFalse($container->has(ConsoleSubscriber::class));
+    }
+
+    public function testMessengerDisabledRemovesMiddleware(): void
+    {
+        $container = $this->boot(['messenger_enabled' => false]);
+
+        self::assertFalse($container->has(OpenTelemetryMiddleware::class));
+    }
+
+    public function testCustomTracerNameWired(): void
+    {
+        $this->boot(['tracer_name' => 'my-app']);
+
+        self::assertSame(
+            'my-app',
+            $this->kernel->getContainer()->getParameter('open_telemetry.tracer_name'),
+        );
+    }
+
+    public function testAllFeaturesDisabledStillBoots(): void
+    {
+        $container = $this->boot([
+            'traces_enabled' => false,
+            'console_enabled' => false,
+            'messenger_enabled' => false,
+            'http_client_enabled' => false,
+            'doctrine_enabled' => false,
+            'cache_enabled' => false,
+            'twig_enabled' => false,
+            'monolog_enabled' => false,
+            'log_export_enabled' => false,
+        ]);
+
+        self::assertInstanceOf(Tracing::class, $container->get(TracingInterface::class));
+    }
+
+    public function testLogExportBootsWithMonologBundle(): void
+    {
+        $container = $this->boot(
+            ['log_export_enabled' => true],
+            [new \Symfony\Bundle\MonologBundle\MonologBundle()],
+        );
+
+        self::assertInstanceOf(OtelLogHandler::class, $container->get(OtelLogHandler::class));
+        self::assertInstanceOf(OtelLoggerFlushSubscriber::class, $container->get(OtelLoggerFlushSubscriber::class));
+    }
+
+    public function testLogExportFailsWithoutMonologBundle(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('symfony/monolog-bundle');
+
+        $this->boot(['log_export_enabled' => true]);
+    }
+
+    public function testHttpClientExcludedHostsParameter(): void
+    {
+        $this->boot(['http_client_excluded_hosts' => ['collector.local']]);
+
+        self::assertSame(
+            ['collector.local'],
+            $this->kernel->getContainer()->getParameter('open_telemetry.http_client_excluded_hosts'),
+        );
+    }
+
+    public function testCacheEnabledByDefault(): void
+    {
+        $this->boot();
+
+        self::assertTrue(
+            $this->kernel->getContainer()->getParameter('open_telemetry.cache_enabled'),
+        );
+    }
+
+    public function testCacheDisabledParameter(): void
+    {
+        $this->boot(['cache_enabled' => false]);
+
+        self::assertFalse(
+            $this->kernel->getContainer()->getParameter('open_telemetry.cache_enabled'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $otelConfig
+     * @param list<\Symfony\Component\HttpKernel\Bundle\BundleInterface> $extraBundles
+     */
+    private function boot(array $otelConfig = [], array $extraBundles = []): \Symfony\Component\DependencyInjection\ContainerInterface
+    {
+        $this->kernel = new OpenTelemetryTestKernel($otelConfig, $extraBundles);
+        $this->kernel->boot();
+
+        return $this->kernel->getContainer();
+    }
+}

--- a/tests/Functional/OpenTelemetryTestKernel.php
+++ b/tests/Functional/OpenTelemetryTestKernel.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Functional;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Traceway\OpenTelemetryBundle\OpenTelemetryBundle;
+
+final class OpenTelemetryTestKernel extends Kernel
+{
+    /** @var array<string, mixed> */
+    private array $otelConfig;
+
+    /** @var list<\Symfony\Component\HttpKernel\Bundle\BundleInterface> */
+    private array $extraBundles;
+
+    /**
+     * @param array<string, mixed> $otelConfig
+     * @param list<\Symfony\Component\HttpKernel\Bundle\BundleInterface> $extraBundles
+     */
+    public function __construct(
+        array $otelConfig = [],
+        array $extraBundles = [],
+    ) {
+        $this->otelConfig = $otelConfig;
+        $this->extraBundles = $extraBundles;
+
+        parent::__construct('test', false);
+    }
+
+    public function registerBundles(): iterable
+    {
+        yield new \Symfony\Bundle\FrameworkBundle\FrameworkBundle();
+
+        foreach ($this->extraBundles as $bundle) {
+            yield $bundle;
+        }
+
+        yield new OpenTelemetryBundle();
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $otelConfig = $this->otelConfig;
+
+        $loader->load(function (ContainerBuilder $container) use ($otelConfig): void {
+            $container->loadFromExtension('framework', [
+                'secret' => 'test',
+                'test' => true,
+                'http_method_override' => false,
+            ]);
+
+            if ([] !== $otelConfig) {
+                $container->loadFromExtension('open_telemetry', $otelConfig);
+            }
+        });
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new class implements CompilerPassInterface {
+            public function process(ContainerBuilder $container): void
+            {
+                foreach ($container->getDefinitions() as $id => $definition) {
+                    if (str_starts_with($id, 'Traceway\\OpenTelemetryBundle\\')) {
+                        $definition->setPublic(true);
+                    }
+                }
+
+                foreach ($container->getAliases() as $id => $alias) {
+                    if (str_starts_with($id, 'Traceway\\OpenTelemetryBundle\\')) {
+                        $alias->setPublic(true);
+                    }
+                }
+            }
+        });
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/otel_bundle_tests/' . spl_object_id($this);
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir() . '/otel_bundle_tests/logs';
+    }
+}

--- a/tests/HttpClient/TracedResponseTest.php
+++ b/tests/HttpClient/TracedResponseTest.php
@@ -202,6 +202,46 @@ final class TracedResponseTest extends TestCase
         self::assertSame('exception', $spans[0]->getEvents()[0]->getName());
     }
 
+    public function testCancelEndsSpan(): void
+    {
+        $response = $this->makeResponse(200, 'OK');
+
+        $response->cancel();
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+    }
+
+    public function testToArrayThrowsOnErrorAndRecordsException(): void
+    {
+        $response = $this->makeResponse(500, '{"error":"fail"}', ['content-type' => 'application/json']);
+
+        try {
+            $response->toArray(true);
+            self::fail('Expected exception');
+        } catch (\Throwable) {
+        }
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        self::assertSame(StatusCode::STATUS_ERROR, $spans[0]->getStatus()->getCode());
+        self::assertNotEmpty($spans[0]->getEvents());
+        self::assertSame('exception', $spans[0]->getEvents()[0]->getName());
+    }
+
+    public function testGetContentEmptyBodyDoesNotSetBodySize(): void
+    {
+        $response = $this->makeResponse(204, '');
+
+        $content = $response->getContent(false);
+
+        self::assertSame('', $content);
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        self::assertArrayNotHasKey('http.response.body.size', $spans[0]->getAttributes()->toArray());
+    }
+
     public function testDestructFinalizesSpanIfNotEnded(): void
     {
         $response = $this->makeResponse(200, 'OK');

--- a/tests/Messenger/OpenTelemetryMiddlewareTest.php
+++ b/tests/Messenger/OpenTelemetryMiddlewareTest.php
@@ -239,6 +239,37 @@ final class OpenTelemetryMiddlewareTest extends TestCase
         self::assertSame(SpanKind::KIND_CONSUMER, $spans[0]->getKind());
     }
 
+    public function testResetClearsTracerCache(): void
+    {
+        $middleware = new OpenTelemetryMiddleware('test');
+        $envelope = new Envelope(new \stdClass());
+
+        $stack = new StackMiddleware();
+        $middleware->handle($envelope, $stack);
+
+        $middleware->reset();
+
+        $envelope2 = new Envelope(new \stdClass());
+        $stack2 = new StackMiddleware();
+        $middleware->handle($envelope2, $stack2);
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(2, $spans);
+    }
+
+    public function testConsumeWithoutReceivedStampOmitsDestination(): void
+    {
+        $middleware = new OpenTelemetryMiddleware('test');
+        $envelope = new Envelope(new \stdClass(), [new ConsumedByWorkerStamp()]);
+
+        $stack = new StackMiddleware();
+        $middleware->handle($envelope, $stack);
+
+        $spans = $this->exporter->getSpans();
+        $attributes = $spans[0]->getAttributes()->toArray();
+        self::assertArrayNotHasKey('messaging.destination.name', $attributes);
+    }
+
     public function testConsumeWithEmptyTraceContextStamp(): void
     {
         $middleware = new OpenTelemetryMiddleware('test', rootSpans: false);

--- a/tests/Monolog/OtelLogHandlerTest.php
+++ b/tests/Monolog/OtelLogHandlerTest.php
@@ -368,6 +368,75 @@ final class OtelLogHandlerTest extends TestCase
         self::assertTrue($emitting->getValue($handler));
     }
 
+    public function testMixedTypeListFallsBackToJsonEncoding(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            context: ['items' => ['text', 42, ['nested' => true]]],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertIsString($attrs['monolog.context.items']);
+        $decoded = json_decode($attrs['monolog.context.items'], true);
+        self::assertSame('text', $decoded[0]);
+        self::assertSame(42, $decoded[1]);
+    }
+
+    public function testNullValueInContextIsPassedAsAttribute(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            context: ['empty' => null, 'present' => 'yes'],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertSame('yes', $attrs['monolog.context.present']);
+    }
+
+    public function testListOfScalarsWithNullsPreserved(): void
+    {
+        $handler = new OtelLogHandler();
+
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Info,
+            message: 'test',
+            context: ['ids' => [1, null, 3]],
+        );
+
+        $handler->handle($record);
+
+        $logs = $this->logExporter->getStorage();
+        /** @var ReadableLogRecord $log */
+        $log = $logs[0];
+        $attrs = $log->getAttributes()->toArray();
+
+        self::assertSame([1, null, 3], $attrs['monolog.context.ids']);
+    }
+
     public function testResetClearsCachedLogger(): void
     {
         $handler = new OtelLogHandler();

--- a/tests/Twig/OpenTelemetryTwigExtensionTest.php
+++ b/tests/Twig/OpenTelemetryTwigExtensionTest.php
@@ -180,6 +180,34 @@ final class OpenTelemetryTwigExtensionTest extends TestCase
         self::assertSame('twig.render debug_page.html.twig', $spans[0]->getName());
     }
 
+    public function testResetDrainsOrphanedSpans(): void
+    {
+        $profile = new Profile('page.html.twig', Profile::TEMPLATE, 'page.html.twig');
+
+        $this->extension->enter($profile);
+        $this->extension->reset();
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        self::assertSame('twig.render page.html.twig', $spans[0]->getName());
+    }
+
+    public function testResetAllowsNewSpansAfterwards(): void
+    {
+        $first = new Profile('old.html.twig', Profile::TEMPLATE, 'old.html.twig');
+        $this->extension->enter($first);
+        $this->extension->reset();
+
+        $second = new Profile('new.html.twig', Profile::TEMPLATE, 'new.html.twig');
+        $this->extension->enter($second);
+        $this->extension->leave($second);
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(2, $spans);
+        self::assertSame('twig.render old.html.twig', $spans[0]->getName());
+        self::assertSame('twig.render new.html.twig', $spans[1]->getName());
+    }
+
     public function testSplObjectIdMatchingHandlesDuplicateTemplateNames(): void
     {
         $first = new Profile('partial.html.twig', Profile::TEMPLATE, 'partial.html.twig');


### PR DESCRIPTION
- Add unit tests covering previously untested code paths: cache PSR-6 delegation, reset
  behavior, Twig `reset()`, OtelLogHandler mixed-type attribute serialization,
  TracedResponse `cancel()` and empty body handling, Messenger `reset()` and destination
  omission

 - Add functional test suite (`tests/Functional/`) that boots a minimal Symfony kernel to
   verify container compilation and service wiring under various config combinations (all
  features enabled, all disabled, log export with/without MonologBundle, custom tracer
  names, excluded hosts/pools)
