### PR TITLE
feat(metrics): add Messenger dispatch metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,13 @@ open_telemetry:
 |---|---|---|---|---|
 | `messaging.process.duration` | Histogram | `s` | Messenger consume | `messaging.system`, `messaging.operation.name`, `messaging.operation.type`, `messaging.destination.name`, `error.type` on failure |
 | `messaging.client.consumed.messages` | Counter | `{message}` | Messenger consume | Same as above |
+| `messaging.client.operation.duration` | Histogram | `s` | Messenger dispatch | Same shape, `messaging.operation.{name,type}` = `send`, destination derived from `SentStamp::getSenderAlias()` (falls back to sender FQCN) |
+| `messaging.client.sent.messages` | Counter | `{message}` | Messenger dispatch | Same as above |
 | `db.client.operation.duration` | Histogram | `s` | DBAL connection | `db.system.name`, `db.namespace`, `server.address`, `server.port`, `db.operation.name`, `db.collection.name` (when extractable), `error.type` on failure |
 
 Names and attributes follow OTel semantic conventions: [messaging metrics](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/) (Development) and [database client metrics](https://opentelemetry.io/docs/specs/semconv/database/database-metrics/) (Stable). The general `error.type` attribute is Stable. Service identity (`service.name`, `service.namespace`, `service.version`) comes from the OTel resource, set via `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`, not from metric name prefixing.
 
-`messenger.excluded_queues` is matched on `ReceivedStamp::getTransportName()` (consume path only). Dispatch-side exclusion and dispatch metrics (`messaging.client.sent.messages`, `messaging.client.operation.duration`) are out of scope for this first metrics drop.
+`messenger.excluded_queues` matches the transport name on both sides — `ReceivedStamp::getTransportName()` on the consume path and `SentStamp::getSenderAlias()` on the dispatch path. A dispatched envelope landing on multiple transports emits one metric point per non-excluded transport.
 
 The DBAL instrumentation wraps every connection produced by Doctrine. It records duration for `Connection::query()`, `Connection::exec()`, prepared `Statement::execute()`, and the transaction control methods (`beginTransaction`, `commit`, `rollBack`). The SQL text itself is **never** recorded — only the leading keyword (`db.operation.name`) and the primary table when it can be extracted unambiguously (`db.collection.name`).
 

--- a/src/Messenger/OpenTelemetryMetricsMiddleware.php
+++ b/src/Messenger/OpenTelemetryMetricsMiddleware.php
@@ -13,30 +13,38 @@ use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Contracts\Service\ResetInterface;
 use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
 /**
- * Emits OpenTelemetry metrics for Symfony Messenger consumer-side processing.
+ * Emits OpenTelemetry metrics for Symfony Messenger, on both the producer
+ * (dispatch) and consumer (process) sides of the bus.
  *
  * Sibling of {@see OpenTelemetryMiddleware}. Lives on the same bus, wired via
- * the extension's prepend() when metrics.messenger.enabled. Dispatch side is
- * out of scope for this first PR; ConsumedByWorkerStamp or ReceivedStamp
- * presence triggers emission.
+ * the extension's prepend() when metrics.messenger.enabled. Dispatch is
+ * detected by the absence of ReceivedStamp/ConsumedByWorkerStamp; consume by
+ * their presence.
  *
- * Metrics (OTel messaging metrics semconv, Development status as of 2026-04):
- *   - messaging.process.duration             (Histogram, seconds)
- *   - messaging.client.consumed.messages     (Counter,  {message})
+ * Metrics (OTel messaging metrics semconv):
+ *   Consume side:
+ *     - messaging.process.duration             (Histogram, seconds)   [Development]
+ *     - messaging.client.consumed.messages     (Counter,  {message})  [Development]
+ *   Dispatch side:
+ *     - messaging.client.operation.duration    (Histogram, seconds)   [Development]
+ *     - messaging.client.sent.messages         (Counter,  {message})  [Development]
  *
- * Attributes (required + conditionally required per spec, trace-compatible):
+ * Attributes:
  *   - messaging.system                  (required) -> "symfony_messenger"
- *   - messaging.operation.name          (required) -> "process"
- *   - messaging.operation.type          (trace-correlation) -> "process"
- *   - messaging.destination.name        (conditional) -> ReceivedStamp::getTransportName()
+ *   - messaging.operation.name          (required) -> "process" | "send"
+ *   - messaging.operation.type          (trace-correlation) -> "process" | "send"
+ *   - messaging.destination.name        (conditional)
+ *       consume: ReceivedStamp::getTransportName()
+ *       dispatch: SentStamp::getSenderAlias() ?? SentStamp::getSenderClass()
  *   - error.type                        (conditional, on failure) -> exception FQCN (parent class for anonymous)
  *
- * excluded_queues matches on the transport name (consume side only), same
- * field the trace middleware uses for messaging.destination.name.
+ * excluded_queues matches the transport name on both sides (one config,
+ * symmetric semantics).
  */
 final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, ResetInterface
 {
@@ -47,6 +55,8 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
     private ?MeterInterface $meter = null;
     private ?HistogramInterface $duration = null;
     private ?CounterInterface $messages = null;
+    private ?HistogramInterface $dispatchDuration = null;
+    private ?CounterInterface $dispatchSent = null;
 
     /** @var list<string> */
     private readonly array $excludedQueues;
@@ -63,10 +73,24 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        if (!$this->isConsuming($envelope)) {
-            return $stack->next()->handle($envelope, $stack);
+        if ($this->isConsuming($envelope)) {
+            return $this->handleConsume($envelope, $stack);
         }
 
+        return $this->handleDispatch($envelope, $stack);
+    }
+
+    public function reset(): void
+    {
+        $this->meter = null;
+        $this->duration = null;
+        $this->messages = null;
+        $this->dispatchDuration = null;
+        $this->dispatchSent = null;
+    }
+
+    private function handleConsume(Envelope $envelope, StackInterface $stack): Envelope
+    {
         /** @var ReceivedStamp|null $receivedStamp */
         $receivedStamp = $envelope->last(ReceivedStamp::class);
         $destination = null !== $receivedStamp ? $receivedStamp->getTransportName() : null;
@@ -92,16 +116,30 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
         }
     }
 
-    public function reset(): void
+    private function handleDispatch(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $this->meter = null;
-        $this->duration = null;
-        $this->messages = null;
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            $envelope = $stack->next()->handle($envelope, $stack);
+
+            return $envelope;
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            try {
+                $this->recordDispatch($envelope, $start, $exception);
+            } catch (\Throwable) {
+            }
+        }
     }
 
     private function record(?string $destination, int|float $start, ?\Throwable $exception): void
     {
-        $attributes = $this->baseAttributes();
+        $attributes = $this->baseAttributes('process');
         if (null !== $destination) {
             $attributes['messaging.destination.name'] = $destination;
         }
@@ -115,15 +153,51 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
         $this->getDurationHistogram()->record($durationSeconds, $attributes);
     }
 
+    private function recordDispatch(Envelope $envelope, int|float $start, ?\Throwable $exception): void
+    {
+        $base = $this->baseAttributes('send');
+        if (null !== $exception) {
+            $base['error.type'] = ErrorTypeResolver::resolve($exception);
+        }
+
+        $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+
+        $sentStamps = $envelope->all(SentStamp::class);
+
+        if ([] === $sentStamps) {
+            $this->getDispatchSentCounter()->add(1, $base);
+            $this->getDispatchDurationHistogram()->record($durationSeconds, $base);
+
+            return;
+        }
+
+        foreach ($sentStamps as $stamp) {
+            /** @var SentStamp $stamp */
+            $destination = $stamp->getSenderAlias() ?? $stamp->getSenderClass();
+
+            if ($this->isExcluded($destination)) {
+                continue;
+            }
+
+            $attributes = $base;
+            $attributes['messaging.destination.name'] = $destination;
+
+            $this->getDispatchSentCounter()->add(1, $attributes);
+            $this->getDispatchDurationHistogram()->record($durationSeconds, $attributes);
+        }
+    }
+
     /**
+     * @param 'process'|'send' $operation
+     *
      * @return array<non-empty-string, string>
      */
-    private function baseAttributes(): array
+    private function baseAttributes(string $operation): array
     {
         return [
             'messaging.system' => 'symfony_messenger',
-            'messaging.operation.name' => 'process',
-            'messaging.operation.type' => 'process',
+            'messaging.operation.name' => $operation,
+            'messaging.operation.type' => $operation,
         ];
     }
 
@@ -162,17 +236,38 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
         );
     }
 
+    private function getDispatchDurationHistogram(): HistogramInterface
+    {
+        return $this->dispatchDuration ??= $this->getMeter()->createHistogram(
+            $this->metricName('dispatch_duration'),
+            's',
+            'Duration of messaging client send operations',
+            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
+        );
+    }
+
+    private function getDispatchSentCounter(): CounterInterface
+    {
+        return $this->dispatchSent ??= $this->getMeter()->createCounter(
+            $this->metricName('sent'),
+            '{message}',
+            'Number of messages sent to a transport',
+        );
+    }
+
     /**
      * Central metric name resolution. Ready for OTEL_SEMCONV_STABILITY_OPT_IN
      * dual-emit once messaging metrics semconv stabilizes.
      *
-     * @param 'duration'|'messages' $key
+     * @param 'duration'|'messages'|'dispatch_duration'|'sent' $key
      */
     private function metricName(string $key): string
     {
         return match ($key) {
             'duration' => 'messaging.process.duration',
             'messages' => 'messaging.client.consumed.messages',
+            'dispatch_duration' => 'messaging.client.operation.duration',
+            'sent' => 'messaging.client.sent.messages',
         };
     }
 }

--- a/tests/Messenger/OpenTelemetryMetricsMiddlewareTest.php
+++ b/tests/Messenger/OpenTelemetryMetricsMiddlewareTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Traceway\OpenTelemetryBundle\Tests\Messenger;
 
 use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\HistogramInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
@@ -12,6 +13,8 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Middleware\StackMiddleware;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMetricsMiddleware;
 use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
 
@@ -89,14 +92,178 @@ final class OpenTelemetryMetricsMiddlewareTest extends TestCase
         self::assertArrayHasKey('messaging.process.duration', $metrics);
     }
 
-    public function testDispatchEmitsNothing(): void
+    public function testDispatchWithoutSentStampsEmitsBaseMetric(): void
     {
         $middleware = new OpenTelemetryMetricsMiddleware('test');
         $envelope = new Envelope(new \stdClass());
 
         $middleware->handle($envelope, new StackMiddleware());
 
-        self::assertSame([], $this->collectMetrics());
+        $metrics = $this->collectMetrics();
+
+        self::assertArrayHasKey('messaging.client.sent.messages', $metrics);
+        $points = [...$metrics['messaging.client.sent.messages']->data->dataPoints];
+        self::assertCount(1, $points);
+        self::assertSame(1, $points[0]->value);
+
+        $attr = $points[0]->attributes->toArray();
+        self::assertSame('symfony_messenger', $attr['messaging.system']);
+        self::assertSame('send', $attr['messaging.operation.name']);
+        self::assertSame('send', $attr['messaging.operation.type']);
+        self::assertArrayNotHasKey('messaging.destination.name', $attr);
+
+        self::assertArrayHasKey('messaging.client.operation.duration', $metrics);
+        self::assertSame('s', $metrics['messaging.client.operation.duration']->unit);
+    }
+
+    public function testDispatchWithSingleSentStampSetsDestinationFromAlias(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test');
+        $envelope = new Envelope(new \stdClass(), [new SentStamp(InMemoryTransport::class, 'async')]);
+
+        $middleware->handle($envelope, new StackMiddleware());
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['messaging.client.sent.messages']->data->dataPoints];
+        self::assertCount(1, $points);
+        self::assertSame('async', $points[0]->attributes->toArray()['messaging.destination.name']);
+    }
+
+    public function testDispatchWithSentStampMissingAliasFallsBackToSenderClass(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test');
+        $envelope = new Envelope(new \stdClass(), [new SentStamp(InMemoryTransport::class, null)]);
+
+        $middleware->handle($envelope, new StackMiddleware());
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['messaging.client.sent.messages']->data->dataPoints];
+        self::assertSame(InMemoryTransport::class, $points[0]->attributes->toArray()['messaging.destination.name']);
+    }
+
+    public function testDispatchWithMultipleSentStampsEmitsPerTransport(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test');
+        $envelope = new Envelope(new \stdClass(), [
+            new SentStamp(InMemoryTransport::class, 'async'),
+            new SentStamp(InMemoryTransport::class, 'audit'),
+        ]);
+
+        $middleware->handle($envelope, new StackMiddleware());
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['messaging.client.sent.messages']->data->dataPoints];
+        $destinations = array_map(
+            static fn ($p): string => $p->attributes->toArray()['messaging.destination.name'],
+            $points,
+        );
+        sort($destinations);
+        self::assertSame(['async', 'audit'], $destinations);
+    }
+
+    public function testDispatchWithExcludedTransportSkipsThatStampOnly(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test', ['audit']);
+        $envelope = new Envelope(new \stdClass(), [
+            new SentStamp(InMemoryTransport::class, 'async'),
+            new SentStamp(InMemoryTransport::class, 'audit'),
+        ]);
+
+        $middleware->handle($envelope, new StackMiddleware());
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['messaging.client.sent.messages']->data->dataPoints];
+        $destinations = array_map(
+            static fn ($p): string => $p->attributes->toArray()['messaging.destination.name'],
+            $points,
+        );
+        self::assertSame(['async'], $destinations);
+    }
+
+    public function testDispatchFailureAddsErrorType(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test');
+        $envelope = new Envelope(new \stdClass());
+
+        $failing = new class implements MiddlewareInterface {
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                throw new \RuntimeException('transport down');
+            }
+        };
+
+        try {
+            $middleware->handle($envelope, new StackMiddleware([$middleware, $failing]));
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['messaging.client.sent.messages']->data->dataPoints];
+        self::assertSame('RuntimeException', $points[0]->attributes->toArray()['error.type']);
+    }
+
+    public function testDispatchDurationHistogramUsesSecondBasedBuckets(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test');
+        $envelope = new Envelope(new \stdClass(), [new SentStamp(InMemoryTransport::class, 'async')]);
+
+        $middleware->handle($envelope, new StackMiddleware());
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['messaging.client.operation.duration']->data->dataPoints];
+        self::assertSame(
+            OpenTelemetryMetricsMiddleware::DURATION_BUCKET_BOUNDARIES,
+            $points[0]->explicitBounds,
+        );
+    }
+
+    public function testDispatchRecordFailureDoesNotMaskTransportException(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test');
+        $this->injectBrokenDispatchSentCounter($middleware);
+
+        $envelope = new Envelope(new \stdClass());
+        $businessException = new \DomainException('transport down');
+
+        $failing = new class($businessException) implements MiddlewareInterface {
+            public function __construct(private readonly \Throwable $e) {}
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                throw $this->e;
+            }
+        };
+
+        try {
+            $middleware->handle($envelope, new StackMiddleware([$middleware, $failing]));
+            self::fail('Expected DomainException');
+        } catch (\DomainException $caught) {
+            self::assertSame($businessException, $caught);
+        }
+    }
+
+    public function testDispatchRecordFailureOnSuccessPathIsSwallowed(): void
+    {
+        $middleware = new OpenTelemetryMetricsMiddleware('test');
+        $this->injectBrokenDispatchSentCounter($middleware);
+
+        $envelope = new Envelope(new \stdClass());
+
+        $result = $middleware->handle($envelope, new StackMiddleware());
+
+        self::assertSame($envelope, $result);
+    }
+
+    private function injectBrokenDispatchSentCounter(OpenTelemetryMetricsMiddleware $middleware): void
+    {
+        $broken = $this->createMock(CounterInterface::class);
+        $broken->method('add')->willThrowException(new \RuntimeException('metrics down'));
+
+        $reflection = new \ReflectionClass($middleware);
+        $property = $reflection->getProperty('dispatchSent');
+        $property->setAccessible(true);
+        $property->setValue($middleware, $broken);
     }
 
     public function testExcludedQueueEmitsNothing(): void


### PR DESCRIPTION
  Second drop in the metrics rollout after #27. Adds producer-side metrics on the Messenger   
  bus, off by default.
                                                                                              
  ## Instruments  

  - `messaging.client.operation.duration` (Histogram, `s`)                                    
  - `messaging.client.sent.messages` (Counter, `{message}`)
                                                                                              
  Attributes follow the messaging semconv: `messaging.system`,                                
  `messaging.operation.name`/`type` = `send`, `messaging.destination.name` from
  `SentStamp::getSenderAlias()` (falls back to sender FQCN), `error.type` on failure.         
  Multi-transport dispatch emits one point per `SentStamp`.

  ## Config

  `metrics.messenger.excluded_queues` now applies symmetrically — same list, same transport   
  names on both sides.
                                                                                              
  ## Notes        

  - Review patterns from #27 already applied: FQCN+anonymous fallback for `error.type`,       
  second-based bucket boundaries, recording wrapped in a swallowing `try`/`catch` so a broken
  provider cannot mask the dispatch exception.                                                
  - 9 new dispatch tests, suite green.
  - The inline `resolveErrorType` helper in `OpenTelemetryMetricsMiddleware` is left untouched
   here. Will migrate to a shared `Util\ErrorTypeResolver` in a follow-up once one of the     
  parallel http-client / http-server / doctrine PRs lands.