### PR TITLE
feat(metrics): add HTTP client metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ open_telemetry:
             excluded_queues: []
         doctrine:
             enabled: false             # emit db.client.operation.duration for every DBAL query/exec/transaction
+        http_client:
+            enabled: false             # emit http.client.request.duration and body size histograms
+            excluded_hosts: []         # OTLP endpoint is auto-excluded
 ```
 
 ### Environment Variables
@@ -176,6 +179,18 @@ Names and attributes follow OTel semantic conventions: [messaging metrics](https
 `messenger.excluded_queues` is matched on `ReceivedStamp::getTransportName()` (consume path only). Dispatch-side exclusion and dispatch metrics (`messaging.client.sent.messages`, `messaging.client.operation.duration`) are out of scope for this first metrics drop.
 
 The DBAL instrumentation wraps every connection produced by Doctrine. It records duration for `Connection::query()`, `Connection::exec()`, prepared `Statement::execute()`, and the transaction control methods (`beginTransaction`, `commit`, `rollBack`). The SQL text itself is **never** recorded — only the leading keyword (`db.operation.name`) and the primary table when it can be extracted unambiguously (`db.collection.name`).
+
+**HTTP Client** (outgoing requests):
+
+| Instrument | Kind | Unit | Stability | Attributes |
+|---|---|---|---|---|
+| `http.client.request.duration` | Histogram | `s` | **Stable** | `http.request.method`, `server.address`, `server.port`, `url.scheme`, `http.response.status_code` on response, `error.type` on transport failure |
+| `http.client.request.body.size` | Histogram | `By` | Development | Same as duration (emitted when `Content-Length` header or a string body is present) |
+| `http.client.response.body.size` | Histogram | `By` | Development | Same as duration (emitted when response `Content-Length` is set or the body is fully read) |
+
+Names follow the [OTel HTTP metrics semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/). `http_client.excluded_hosts` is a list of hostnames to skip; the OTLP endpoint (from `OTEL_EXPORTER_OTLP_ENDPOINT`) is always auto-excluded to prevent instrumentation loops.
+
+Connection-pool metrics (`http.client.open_connections`, `http.client.connection.duration`, `http.client.active_requests`) require low-level access to the HTTP client pool that Symfony HttpClient does not expose; they are out of scope for this drop.
 
 ### Manual Instrumentation
 

--- a/src/DependencyInjection/Compiler/HttpClientMetricsPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientMetricsPass.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Traceway\OpenTelemetryBundle\HttpClient\MeteredHttpClient;
+
+/**
+ * Decorates all services tagged with 'http_client.client' and the default
+ * 'http_client' service with {@see MeteredHttpClient} when metrics are
+ * enabled for the HTTP client subsystem.
+ *
+ * Decoration priority is -8, higher than {@see HttpClientTracingPass}'s -16,
+ * so the metrics decorator wraps the trace decorator. Recorded duration
+ * therefore reflects what the app observes, including any overhead added by
+ * the tracing layer underneath.
+ */
+final class HttpClientMetricsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('open_telemetry.http_client_metrics_enabled')) {
+            return;
+        }
+
+        if (!$container->getParameter('open_telemetry.http_client_metrics_enabled')) {
+            return;
+        }
+
+        $meterName = $container->getParameter('open_telemetry.metrics_meter_name');
+        \assert(\is_string($meterName));
+
+        /** @var string[] $excludedHosts */
+        $excludedHosts = $container->hasParameter('open_telemetry.http_client_metrics_excluded_hosts')
+            ? $container->getParameter('open_telemetry.http_client_metrics_excluded_hosts')
+            : [];
+
+        foreach ($this->findHttpClientServiceIds($container) as $clientId) {
+            $decoratorId = $clientId . '.otel_metrics';
+            $innerId = $decoratorId . '.inner';
+
+            $decorator = new Definition(MeteredHttpClient::class);
+            $decorator->setArgument('$client', new Reference($innerId));
+            $decorator->setArgument('$meterName', $meterName);
+            $decorator->setArgument('$excludedHosts', $excludedHosts);
+            $decorator->setDecoratedService($clientId, $innerId, -8);
+
+            $container->setDefinition($decoratorId, $decorator);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findHttpClientServiceIds(ContainerBuilder $container): array
+    {
+        $ids = [];
+
+        if ($container->has('http_client')) {
+            $ids[] = 'http_client';
+        }
+
+        foreach ($container->findTaggedServiceIds('http_client.client') as $id => $tags) {
+            if (!\in_array($id, $ids, true)) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -158,6 +158,21 @@ final class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->arrayNode('http_client')
+                            ->info('Automatic metrics for outgoing HTTP client requests.')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('enabled')
+                                    ->info('Emit http.client.request.duration (histogram), http.client.request.body.size and http.client.response.body.size (histograms) on outgoing requests. Requires metrics.enabled and symfony/http-client.')
+                                    ->defaultFalse()
+                                ->end()
+                                ->arrayNode('excluded_hosts')
+                                    ->info('Hostnames to skip when emitting HTTP client metrics. The OTLP endpoint is auto-excluded.')
+                                    ->scalarPrototype()->end()
+                                    ->defaultValue([])
+                                ->end()
+                            ->end()
+                        ->end()
                     ->end()
                     ->validate()
                         ->ifTrue(static function (array $c): bool {
@@ -172,6 +187,13 @@ final class Configuration implements ConfigurationInterface
                             return true === ($doctrine['enabled'] ?? false) && true !== ($c['enabled'] ?? false);
                         })
                         ->thenInvalid('"open_telemetry.metrics.doctrine.enabled" requires "open_telemetry.metrics.enabled" to be true.')
+                    ->end()
+                    ->validate()
+                        ->ifTrue(static function (array $c): bool {
+                            $httpClient = \is_array($c['http_client'] ?? null) ? $c['http_client'] : [];
+                            return true === ($httpClient['enabled'] ?? false) && true !== ($c['enabled'] ?? false);
+                        })
+                        ->thenInvalid('"open_telemetry.metrics.http_client.enabled" requires "open_telemetry.metrics.enabled" to be true.')
                     ->end()
                 ->end()
             ->end()

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -161,7 +161,7 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->setDefinition(TraceContextProcessor::class, $monologDef);
         }
 
-        /** @var array{enabled: bool, meter_name: string, messenger: array{enabled: bool, excluded_queues: list<string>}} $metrics */
+        /** @var array{enabled: bool, meter_name: string, messenger: array{enabled: bool, excluded_queues: list<string>}, doctrine: array{enabled: bool}, http_client: array{enabled: bool, excluded_hosts: list<string>}} $metrics */
         $metrics = $config['metrics'];
         $meterName = $metrics['meter_name'];
 
@@ -181,14 +181,17 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->removeDefinition(OpenTelemetryMetricsMiddleware::class);
         }
 
-        /** @var array{doctrine?: array{enabled: bool}} $metricsTyped */
-        $metricsTyped = $metrics;
-        if ($metrics['enabled'] && ($metricsTyped['doctrine']['enabled'] ?? false) && $this->isDoctrineAvailable()) {
+        if ($metrics['enabled'] && $metrics['doctrine']['enabled'] && $this->isDoctrineAvailable()) {
             $definition = new Definition(DoctrineMeteredMiddleware::class);
             $definition->setArgument('$meterName', $meterName);
             $definition->addTag('doctrine.middleware');
             $container->setDefinition(DoctrineMeteredMiddleware::class, $definition);
         }
+
+        $httpClientMetricsEnabled = $metrics['enabled'] && $metrics['http_client']['enabled'] && $this->isHttpClientAvailable();
+        $container->setParameter('open_telemetry.http_client_metrics_enabled', $httpClientMetricsEnabled);
+        $container->setParameter('open_telemetry.metrics_meter_name', $meterName);
+        $container->setParameter('open_telemetry.http_client_metrics_excluded_hosts', $metrics['http_client']['excluded_hosts']);
     }
 
     private function isConsoleAvailable(): bool

--- a/src/HttpClient/MeteredHttpClient.php
+++ b/src/HttpClient/MeteredHttpClient.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\HttpClient;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
+use OpenTelemetry\SemConv\Attributes\HttpAttributes;
+use OpenTelemetry\SemConv\Attributes\ServerAttributes;
+use OpenTelemetry\SemConv\Attributes\UrlAttributes;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Decorates any Symfony HttpClient to emit OpenTelemetry metrics for
+ * outgoing requests, sibling of {@see TraceableHttpClient} on the trace side.
+ *
+ * Includes the same re-entrance guard as the trace decorator: if an outgoing
+ * HTTP call is triggered while already inside a measured call (e.g. the OTLP
+ * exporter sending metrics via this client), the nested call passes through
+ * without recording.
+ *
+ * Metrics (OTel HTTP client metrics semconv):
+ *   - http.client.request.duration       (Histogram, s)  [Stable]
+ *   - http.client.request.body.size      (Histogram, By) [Development]
+ *   - http.client.response.body.size     (Histogram, By) [Development]
+ *
+ * Attributes:
+ *   - http.request.method        (required) [Stable]
+ *   - server.address             (required) [Stable]
+ *   - server.port                (required) [Stable]
+ *   - url.scheme                 [Stable]
+ *   - http.response.status_code  (on response) [Stable]
+ *   - error.type                 (on failure) [Stable]
+ */
+final class MeteredHttpClient implements HttpClientInterface, ResetInterface
+{
+    private ?MeterInterface $meter = null;
+    private ?HistogramInterface $duration = null;
+    private ?HistogramInterface $requestBodySize = null;
+    private ?HistogramInterface $responseBodySize = null;
+
+    private ?string $otlpEndpoint = null;
+    private bool $otlpEndpointResolved = false;
+
+    /** Prevents recursive instrumentation when the exporter uses this client. */
+    private bool $inFlight = false;
+
+    /** @var list<string> */
+    private readonly array $excludedHosts;
+
+    /**
+     * @param string[] $excludedHosts Hostnames to skip metrics for (e.g. OTLP collector)
+     */
+    public function __construct(
+        private HttpClientInterface $client,
+        private readonly string $meterName = 'opentelemetry-symfony',
+        array $excludedHosts = [],
+    ) {
+        $this->excludedHosts = array_map('strtolower', array_values($excludedHosts));
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        if ($this->inFlight || $this->isExcluded($url)) {
+            return $this->client->request($method, $url, $options);
+        }
+
+        $attributes = $this->requestAttributes($method, $url);
+        $bodySize = $this->extractRequestBodySize($options);
+
+        if (null !== $bodySize) {
+            $this->getRequestBodySizeHistogram()->record($bodySize, $attributes);
+        }
+
+        $start = hrtime(true);
+        $this->inFlight = true;
+
+        try {
+            $response = $this->client->request($method, $url, $options);
+        } catch (\Throwable $e) {
+            $this->recordFailure($start, $attributes, $e);
+            $this->inFlight = false;
+
+            throw $e;
+        }
+
+        $this->inFlight = false;
+
+        return new MeteredResponse($response, $this, $start, $attributes);
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
+        $underlyingResponses = [];
+
+        /** @var ResponseInterface $response */
+        foreach ($responses as $response) {
+            $underlyingResponses[] = $response instanceof MeteredResponse
+                ? $response->getInnerResponse()
+                : $response;
+        }
+
+        return $this->client->stream($underlyingResponses, $timeout);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $this->client->withOptions($options);
+
+        return $clone;
+    }
+
+    public function reset(): void
+    {
+        $this->meter = null;
+        $this->duration = null;
+        $this->requestBodySize = null;
+        $this->responseBodySize = null;
+        $this->otlpEndpoint = null;
+        $this->otlpEndpointResolved = false;
+        $this->inFlight = false;
+
+        if ($this->client instanceof ResetInterface) {
+            $this->client->reset();
+        }
+    }
+
+    /**
+     * @internal called by {@see MeteredResponse} when the response finalizes successfully
+     *
+     * @param array<non-empty-string, string|int> $attributes
+     */
+    public function recordResponse(int|float $start, array $attributes, int $statusCode, ?int $responseBodySize): void
+    {
+        $attributes[HttpAttributes::HTTP_RESPONSE_STATUS_CODE] = $statusCode;
+
+        $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+        $this->getDurationHistogram()->record($durationSeconds, $attributes);
+
+        if (null !== $responseBodySize) {
+            $this->getResponseBodySizeHistogram()->record($responseBodySize, $attributes);
+        }
+    }
+
+    /**
+     * @internal called by {@see MeteredResponse} or by {@see self::request} when a request/response fails
+     *
+     * @param array<non-empty-string, string|int> $attributes
+     */
+    public function recordFailure(int|float $start, array $attributes, \Throwable $exception): void
+    {
+        $attributes[ErrorAttributes::ERROR_TYPE] = (new \ReflectionClass($exception))->getShortName();
+
+        $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+        $this->getDurationHistogram()->record($durationSeconds, $attributes);
+    }
+
+    /**
+     * @return array<non-empty-string, string|int>
+     */
+    private function requestAttributes(string $method, string $url): array
+    {
+        $parsed = parse_url($url);
+        $host = \is_array($parsed) ? ($parsed['host'] ?? 'unknown') : 'unknown';
+
+        $attributes = [
+            HttpAttributes::HTTP_REQUEST_METHOD => $method,
+            ServerAttributes::SERVER_ADDRESS => $host,
+        ];
+
+        if (\is_array($parsed)) {
+            if (isset($parsed['port'])) {
+                $attributes[ServerAttributes::SERVER_PORT] = (int) $parsed['port'];
+            }
+            if (isset($parsed['scheme'])) {
+                $attributes[UrlAttributes::URL_SCHEME] = $parsed['scheme'];
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function extractRequestBodySize(array $options): ?int
+    {
+        if (isset($options['headers']) && \is_array($options['headers'])) {
+            foreach ($options['headers'] as $name => $value) {
+                if (!\is_string($name) || 'content-length' !== strtolower($name)) {
+                    continue;
+                }
+                $size = \is_array($value) ? ($value[0] ?? null) : $value;
+                if (is_numeric($size)) {
+                    return (int) $size;
+                }
+            }
+        }
+
+        if (isset($options['body']) && \is_string($options['body'])) {
+            return \strlen($options['body']);
+        }
+
+        return null;
+    }
+
+    private function isExcluded(string $url): bool
+    {
+        if ([] === $this->excludedHosts) {
+            return $this->isOtlpEndpoint($url);
+        }
+
+        $host = strtolower((string) (parse_url($url, \PHP_URL_HOST) ?? ''));
+
+        foreach ($this->excludedHosts as $excluded) {
+            if ($host === $excluded) {
+                return true;
+            }
+        }
+
+        return $this->isOtlpEndpoint($url);
+    }
+
+    private function isOtlpEndpoint(string $url): bool
+    {
+        if (!$this->otlpEndpointResolved) {
+            $endpoint = $_SERVER['OTEL_EXPORTER_OTLP_ENDPOINT']
+                ?? $_ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
+                ?? getenv('OTEL_EXPORTER_OTLP_ENDPOINT');
+
+            $this->otlpEndpoint = (\is_string($endpoint) && '' !== $endpoint) ? $endpoint : null;
+            $this->otlpEndpointResolved = true;
+        }
+
+        return null !== $this->otlpEndpoint && str_starts_with($url, $this->otlpEndpoint);
+    }
+
+    private function getMeter(): MeterInterface
+    {
+        return $this->meter ??= Globals::meterProvider()->getMeter($this->meterName);
+    }
+
+    private function getDurationHistogram(): HistogramInterface
+    {
+        return $this->duration ??= $this->getMeter()->createHistogram(
+            $this->metricName('duration'),
+            's',
+            'Duration of outbound HTTP client requests',
+        );
+    }
+
+    private function getRequestBodySizeHistogram(): HistogramInterface
+    {
+        return $this->requestBodySize ??= $this->getMeter()->createHistogram(
+            $this->metricName('request_body_size'),
+            'By',
+            'Size of HTTP client request bodies',
+        );
+    }
+
+    private function getResponseBodySizeHistogram(): HistogramInterface
+    {
+        return $this->responseBodySize ??= $this->getMeter()->createHistogram(
+            $this->metricName('response_body_size'),
+            'By',
+            'Size of HTTP client response bodies',
+        );
+    }
+
+    /**
+     * Central metric name resolution. Ready for OTEL_SEMCONV_STABILITY_OPT_IN
+     * dual-emit once further spec revisions introduce alternative names.
+     *
+     * @param 'duration'|'request_body_size'|'response_body_size' $key
+     */
+    private function metricName(string $key): string
+    {
+        return match ($key) {
+            'duration' => 'http.client.request.duration',
+            'request_body_size' => 'http.client.request.body.size',
+            'response_body_size' => 'http.client.response.body.size',
+        };
+    }
+}

--- a/src/HttpClient/MeteredHttpClient.php
+++ b/src/HttpClient/MeteredHttpClient.php
@@ -40,6 +40,10 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 final class MeteredHttpClient implements HttpClientInterface, ResetInterface
 {
+    public const DURATION_BUCKET_BOUNDARIES = [
+        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+    ];
+
     private ?MeterInterface $meter = null;
     private ?HistogramInterface $duration = null;
     private ?HistogramInterface $requestBodySize = null;
@@ -274,6 +278,7 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
             $this->metricName('duration'),
             's',
             'Duration of outbound HTTP client requests',
+            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
         );
     }
 

--- a/src/HttpClient/MeteredHttpClient.php
+++ b/src/HttpClient/MeteredHttpClient.php
@@ -166,10 +166,21 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
      */
     public function recordFailure(int|float $start, array $attributes, \Throwable $exception): void
     {
-        $attributes[ErrorAttributes::ERROR_TYPE] = (new \ReflectionClass($exception))->getShortName();
+        $attributes[ErrorAttributes::ERROR_TYPE] = self::resolveErrorType($exception);
 
         $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
         $this->getDurationHistogram()->record($durationSeconds, $attributes);
+    }
+
+    private static function resolveErrorType(\Throwable $exception): string
+    {
+        $type = $exception::class;
+
+        if (str_contains($type, '@anonymous')) {
+            $type = get_parent_class($exception) ?: \Throwable::class;
+        }
+
+        return $type;
     }
 
     /**

--- a/src/HttpClient/MeteredHttpClient.php
+++ b/src/HttpClient/MeteredHttpClient.php
@@ -82,7 +82,10 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
         $bodySize = $this->extractRequestBodySize($options);
 
         if (null !== $bodySize) {
-            $this->getRequestBodySizeHistogram()->record($bodySize, $attributes);
+            try {
+                $this->getRequestBodySizeHistogram()->record($bodySize, $attributes);
+            } catch (\Throwable) {
+            }
         }
 
         $start = hrtime(true);
@@ -92,12 +95,11 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
             $response = $this->client->request($method, $url, $options);
         } catch (\Throwable $e) {
             $this->recordFailure($start, $attributes, $e);
-            $this->inFlight = false;
 
             throw $e;
+        } finally {
+            $this->inFlight = false;
         }
-
-        $this->inFlight = false;
 
         return new MeteredResponse($response, $this, $start, $attributes);
     }
@@ -153,13 +155,16 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
      */
     public function recordResponse(int|float $start, array $attributes, int $statusCode, ?int $responseBodySize): void
     {
-        $attributes[HttpAttributes::HTTP_RESPONSE_STATUS_CODE] = $statusCode;
+        try {
+            $attributes[HttpAttributes::HTTP_RESPONSE_STATUS_CODE] = $statusCode;
 
-        $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
-        $this->getDurationHistogram()->record($durationSeconds, $attributes);
+            $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+            $this->getDurationHistogram()->record($durationSeconds, $attributes);
 
-        if (null !== $responseBodySize) {
-            $this->getResponseBodySizeHistogram()->record($responseBodySize, $attributes);
+            if (null !== $responseBodySize) {
+                $this->getResponseBodySizeHistogram()->record($responseBodySize, $attributes);
+            }
+        } catch (\Throwable) {
         }
     }
 
@@ -170,10 +175,13 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
      */
     public function recordFailure(int|float $start, array $attributes, \Throwable $exception): void
     {
-        $attributes[ErrorAttributes::ERROR_TYPE] = self::resolveErrorType($exception);
+        try {
+            $attributes[ErrorAttributes::ERROR_TYPE] = self::resolveErrorType($exception);
 
-        $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
-        $this->getDurationHistogram()->record($durationSeconds, $attributes);
+            $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+            $this->getDurationHistogram()->record($durationSeconds, $attributes);
+        } catch (\Throwable) {
+        }
     }
 
     private static function resolveErrorType(\Throwable $exception): string

--- a/src/HttpClient/MeteredHttpClient.php
+++ b/src/HttpClient/MeteredHttpClient.php
@@ -15,6 +15,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 use Symfony\Contracts\Service\ResetInterface;
+use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
 /**
  * Decorates any Symfony HttpClient to emit OpenTelemetry metrics for
@@ -176,23 +177,12 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
     public function recordFailure(int|float $start, array $attributes, \Throwable $exception): void
     {
         try {
-            $attributes[ErrorAttributes::ERROR_TYPE] = self::resolveErrorType($exception);
+            $attributes[ErrorAttributes::ERROR_TYPE] = ErrorTypeResolver::resolve($exception);
 
             $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
             $this->getDurationHistogram()->record($durationSeconds, $attributes);
         } catch (\Throwable) {
         }
-    }
-
-    private static function resolveErrorType(\Throwable $exception): string
-    {
-        $type = $exception::class;
-
-        if (str_contains($type, '@anonymous')) {
-            $type = get_parent_class($exception) ?: \Throwable::class;
-        }
-
-        return $type;
     }
 
     /**

--- a/src/HttpClient/MeteredHttpClient.php
+++ b/src/HttpClient/MeteredHttpClient.php
@@ -11,6 +11,7 @@ use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 use OpenTelemetry\SemConv\Attributes\HttpAttributes;
 use OpenTelemetry\SemConv\Attributes\ServerAttributes;
 use OpenTelemetry\SemConv\Attributes\UrlAttributes;
+use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -111,16 +112,25 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
             $responses = [$responses];
         }
 
+        $meteredMap = new \SplObjectStorage();
         $underlyingResponses = [];
 
-        /** @var ResponseInterface $response */
         foreach ($responses as $response) {
-            $underlyingResponses[] = $response instanceof MeteredResponse
-                ? $response->getInnerResponse()
-                : $response;
+            if ($response instanceof MeteredResponse) {
+                $inner = $response->getInnerResponse();
+                $meteredMap[$inner] = $response;
+                $underlyingResponses[] = $inner;
+            } else {
+                $meteredMap[$response] = $response;
+                $underlyingResponses[] = $response;
+            }
         }
 
-        return $this->client->stream($underlyingResponses, $timeout);
+        return new ResponseStream((function () use ($meteredMap, $underlyingResponses, $timeout) {
+            foreach ($this->client->stream($underlyingResponses, $timeout) as $response => $chunk) {
+                yield $meteredMap[$response] => $chunk;
+            }
+        })());
     }
 
     /**

--- a/src/HttpClient/MeteredResponse.php
+++ b/src/HttpClient/MeteredResponse.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\HttpClient;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Wraps a response to finalize HTTP client metrics once the response resolves.
+ *
+ * Symfony HttpClient responses are lazy: the actual HTTP call happens when
+ * the caller first accesses getStatusCode(), getHeaders() or getContent().
+ * This wrapper ensures metrics are recorded at that moment with the correct
+ * status code and body size, mirroring {@see TracedResponse} on the trace side.
+ */
+final class MeteredResponse implements ResponseInterface
+{
+    private bool $finalized = false;
+
+    /**
+     * @param array<non-empty-string, string|int> $attributes
+     */
+    public function __construct(
+        private readonly ResponseInterface $response,
+        private readonly MeteredHttpClient $recorder,
+        private readonly int|float $start,
+        private readonly array $attributes,
+    ) {}
+
+    public function getStatusCode(): int
+    {
+        $statusCode = $this->response->getStatusCode();
+        $this->finalize($statusCode, null);
+
+        return $statusCode;
+    }
+
+    public function getHeaders(bool $throw = true): array
+    {
+        try {
+            $headers = $this->response->getHeaders($throw);
+        } catch (\Throwable $e) {
+            $this->finalizeWithError($e);
+            throw $e;
+        }
+
+        $bodySize = null;
+        if (isset($headers['content-length'][0]) && is_numeric($headers['content-length'][0])) {
+            $bodySize = (int) $headers['content-length'][0];
+        }
+
+        $this->safeFinalize($bodySize);
+
+        return $headers;
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        try {
+            $content = $this->response->getContent($throw);
+        } catch (\Throwable $e) {
+            $this->finalizeWithError($e);
+            throw $e;
+        }
+
+        $bodySize = '' !== $content ? \strlen($content) : null;
+        $this->safeFinalize($bodySize);
+
+        return $content;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function toArray(bool $throw = true): array
+    {
+        try {
+            $array = $this->response->toArray($throw);
+        } catch (\Throwable $e) {
+            $this->finalizeWithError($e);
+            throw $e;
+        }
+
+        $this->safeFinalize(null);
+
+        return $array;
+    }
+
+    public function cancel(): void
+    {
+        $this->finalized = true;
+        $this->response->cancel();
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        return $this->response->getInfo($type);
+    }
+
+    public function getInnerResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    public function __destruct()
+    {
+        if ($this->finalized) {
+            return;
+        }
+
+        try {
+            $this->finalize($this->response->getStatusCode(), null);
+        } catch (\Throwable) {
+            // Destructor must not throw.
+        }
+    }
+
+    private function safeFinalize(?int $bodySize): void
+    {
+        try {
+            $this->finalize($this->response->getStatusCode(), $bodySize);
+        } catch (\Throwable $e) {
+            $this->finalizeWithError($e);
+        }
+    }
+
+    private function finalize(int $statusCode, ?int $bodySize): void
+    {
+        if ($this->finalized) {
+            return;
+        }
+
+        $this->finalized = true;
+        $this->recorder->recordResponse($this->start, $this->attributes, $statusCode, $bodySize);
+    }
+
+    private function finalizeWithError(\Throwable $e): void
+    {
+        if ($this->finalized) {
+            return;
+        }
+
+        $this->finalized = true;
+        $this->recorder->recordFailure($this->start, $this->attributes, $e);
+    }
+}

--- a/src/OpenTelemetryBundle.php
+++ b/src/OpenTelemetryBundle.php
@@ -7,6 +7,7 @@ namespace Traceway\OpenTelemetryBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\CacheTracingPass;
+use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\HttpClientMetricsPass;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\HttpClientTracingPass;
 
 final class OpenTelemetryBundle extends Bundle
@@ -21,6 +22,7 @@ final class OpenTelemetryBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new HttpClientTracingPass());
+        $container->addCompilerPass(new HttpClientMetricsPass());
         $container->addCompilerPass(new CacheTracingPass());
     }
 }

--- a/tests/DependencyInjection/Compiler/HttpClientMetricsPassTest.php
+++ b/tests/DependencyInjection/Compiler/HttpClientMetricsPassTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\HttpClientMetricsPass;
+use Traceway\OpenTelemetryBundle\HttpClient\MeteredHttpClient;
+
+final class HttpClientMetricsPassTest extends TestCase
+{
+    public function testDecoratesDefaultHttpClient(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('open_telemetry.http_client_metrics_enabled', true);
+        $container->setParameter('open_telemetry.metrics_meter_name', 'test-meter');
+        $container->setParameter('open_telemetry.http_client_metrics_excluded_hosts', ['cdn.example.com']);
+        $container->setDefinition('http_client', new Definition(HttpClientInterface::class));
+
+        (new HttpClientMetricsPass())->process($container);
+
+        self::assertTrue($container->hasDefinition('http_client.otel_metrics'));
+
+        $decorator = $container->getDefinition('http_client.otel_metrics');
+        self::assertSame(MeteredHttpClient::class, $decorator->getClass());
+        self::assertSame('test-meter', $decorator->getArgument('$meterName'));
+        self::assertSame(['cdn.example.com'], $decorator->getArgument('$excludedHosts'));
+    }
+
+    public function testFallsBackToEmptyExcludedHostsWhenParameterMissing(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('open_telemetry.http_client_metrics_enabled', true);
+        $container->setParameter('open_telemetry.metrics_meter_name', 'test-meter');
+        $container->setDefinition('http_client', new Definition(HttpClientInterface::class));
+
+        (new HttpClientMetricsPass())->process($container);
+
+        $decorator = $container->getDefinition('http_client.otel_metrics');
+        self::assertSame([], $decorator->getArgument('$excludedHosts'));
+    }
+
+    public function testDecoratesTaggedScopedClients(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('open_telemetry.http_client_metrics_enabled', true);
+        $container->setParameter('open_telemetry.metrics_meter_name', 'test-meter');
+
+        $scopedDef = new Definition(HttpClientInterface::class);
+        $scopedDef->addTag('http_client.client');
+        $container->setDefinition('my_api.client', $scopedDef);
+
+        (new HttpClientMetricsPass())->process($container);
+
+        self::assertTrue($container->hasDefinition('my_api.client.otel_metrics'));
+    }
+
+    public function testSkipsWhenDisabled(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('open_telemetry.http_client_metrics_enabled', false);
+        $container->setDefinition('http_client', new Definition(HttpClientInterface::class));
+
+        (new HttpClientMetricsPass())->process($container);
+
+        self::assertFalse($container->hasDefinition('http_client.otel_metrics'));
+    }
+
+    public function testSkipsWhenParameterMissing(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('http_client', new Definition(HttpClientInterface::class));
+
+        (new HttpClientMetricsPass())->process($container);
+
+        self::assertFalse($container->hasDefinition('http_client.otel_metrics'));
+    }
+}

--- a/tests/Functional/BundleBootTest.php
+++ b/tests/Functional/BundleBootTest.php
@@ -230,6 +230,38 @@ final class BundleBootTest extends TestCase
         ]);
     }
 
+    public function testHttpClientMetricsDisabledByDefault(): void
+    {
+        $container = $this->boot(['metrics' => ['enabled' => true]]);
+
+        self::assertFalse($container->getParameter('open_telemetry.http_client_metrics_enabled'));
+    }
+
+    public function testHttpClientMetricsEnabledSetsParameter(): void
+    {
+        $container = $this->boot([
+            'metrics' => [
+                'enabled' => true,
+                'http_client' => ['enabled' => true, 'excluded_hosts' => ['cdn.example.com']],
+            ],
+        ]);
+
+        self::assertTrue($container->getParameter('open_telemetry.http_client_metrics_enabled'));
+        self::assertSame(['cdn.example.com'], $container->getParameter('open_telemetry.http_client_metrics_excluded_hosts'));
+    }
+
+    public function testHttpClientMetricsWithoutMetricsEnabledFails(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('metrics.http_client.enabled');
+
+        $this->boot([
+            'metrics' => [
+                'http_client' => ['enabled' => true],
+            ],
+        ]);
+    }
+
     /**
      * @param array<string, mixed> $otelConfig
      * @param list<\Symfony\Component\HttpKernel\Bundle\BundleInterface> $extraBundles

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -281,4 +281,19 @@ final class MeteredHttpClientTest extends TestCase
         $points = [...$metrics['http.client.request.duration']->data->dataPoints];
         self::assertSame('RuntimeException', $points[0]->attributes->toArray()['error.type']);
     }
+
+    public function testDurationHistogramUsesSecondBasedBuckets(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $client->request('GET', 'https://api.example.com/data')->getStatusCode();
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['http.client.request.duration']->data->dataPoints];
+        self::assertSame(
+            MeteredHttpClient::DURATION_BUCKET_BOUNDARIES,
+            $points[0]->explicitBounds,
+        );
+    }
 }

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -242,4 +242,43 @@ final class MeteredHttpClientTest extends TestCase
         }
         self::assertSame(2, $total);
     }
+
+    public function testNamespacedTransportFailureUsesFqcn(): void
+    {
+        $mockClient = new MockHttpClient(function () {
+            throw new \Symfony\Component\HttpClient\Exception\TransportException('connection refused');
+        });
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        try {
+            $client->request('GET', 'https://api.example.com/data')->getContent();
+            self::fail('Expected exception');
+        } catch (\Throwable) {
+        }
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['http.client.request.duration']->data->dataPoints];
+        self::assertSame(
+            \Symfony\Component\HttpClient\Exception\TransportException::class,
+            $points[0]->attributes->toArray()['error.type'],
+        );
+    }
+
+    public function testAnonymousTransportFailureFallsBackToParentClass(): void
+    {
+        $mockClient = new MockHttpClient(function () {
+            throw new class('boom') extends \RuntimeException {};
+        });
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        try {
+            $client->request('GET', 'https://api.example.com/data')->getContent();
+            self::fail('Expected exception');
+        } catch (\Throwable) {
+        }
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['http.client.request.duration']->data->dataPoints];
+        self::assertSame('RuntimeException', $points[0]->attributes->toArray()['error.type']);
+    }
 }

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Traceway\OpenTelemetryBundle\Tests\HttpClient;
 
+use OpenTelemetry\API\Metrics\HistogramInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -295,5 +296,68 @@ final class MeteredHttpClientTest extends TestCase
             MeteredHttpClient::DURATION_BUCKET_BOUNDARIES,
             $points[0]->explicitBounds,
         );
+    }
+
+    public function testRecordResponseFailureIsSwallowed(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+        $this->injectBrokenDurationHistogram($client);
+
+        $statusCode = $client->request('GET', 'https://api.example.com/data')->getStatusCode();
+
+        self::assertSame(200, $statusCode);
+    }
+
+    public function testRecordFailureDoesNotMaskTransportException(): void
+    {
+        $businessException = new \DomainException('connection refused');
+        $mockClient = new MockHttpClient(function () use ($businessException) {
+            throw $businessException;
+        });
+        $client = new MeteredHttpClient($mockClient, 'test');
+        $this->injectBrokenDurationHistogram($client);
+
+        try {
+            $client->request('GET', 'https://api.example.com/data')->getContent();
+            self::fail('Expected DomainException');
+        } catch (\DomainException $caught) {
+            self::assertSame($businessException, $caught);
+        }
+    }
+
+    public function testRequestBodySizeRecordingFailureIsSwallowed(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+        $this->injectBrokenRequestBodySizeHistogram($client);
+
+        $statusCode = $client->request('POST', 'https://api.example.com/items', [
+            'body' => '{"name":"foo"}',
+        ])->getStatusCode();
+
+        self::assertSame(200, $statusCode);
+    }
+
+    private function injectBrokenDurationHistogram(MeteredHttpClient $client): void
+    {
+        $broken = $this->createMock(HistogramInterface::class);
+        $broken->method('record')->willThrowException(new \RuntimeException('metrics down'));
+
+        $reflection = new \ReflectionClass($client);
+        $duration = $reflection->getProperty('duration');
+        $duration->setAccessible(true);
+        $duration->setValue($client, $broken);
+    }
+
+    private function injectBrokenRequestBodySizeHistogram(MeteredHttpClient $client): void
+    {
+        $broken = $this->createMock(HistogramInterface::class);
+        $broken->method('record')->willThrowException(new \RuntimeException('metrics down'));
+
+        $reflection = new \ReflectionClass($client);
+        $requestBodySize = $reflection->getProperty('requestBodySize');
+        $requestBodySize->setAccessible(true);
+        $requestBodySize->setValue($client, $broken);
     }
 }

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\HttpClient;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Traceway\OpenTelemetryBundle\HttpClient\MeteredHttpClient;
+use Traceway\OpenTelemetryBundle\HttpClient\MeteredResponse;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+final class MeteredHttpClientTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownOTel();
+    }
+
+    public function testRequestEmitsDurationWithRequiredAttributes(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('GET', 'https://api.example.com:8443/users');
+        $response->getStatusCode();
+
+        $metrics = $this->collectMetrics();
+
+        self::assertArrayHasKey('http.client.request.duration', $metrics);
+        $duration = $metrics['http.client.request.duration'];
+        self::assertSame('s', $duration->unit);
+
+        $points = [...$duration->data->dataPoints];
+        self::assertCount(1, $points);
+        self::assertSame(1, $points[0]->count);
+
+        $attr = $points[0]->attributes->toArray();
+        self::assertSame('GET', $attr['http.request.method']);
+        self::assertSame('api.example.com', $attr['server.address']);
+        self::assertSame(8443, $attr['server.port']);
+        self::assertSame('https', $attr['url.scheme']);
+        self::assertSame(200, $attr['http.response.status_code']);
+        self::assertArrayNotHasKey('error.type', $attr);
+    }
+
+    public function testResponseBodySizeFromHeaders(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('payload', [
+            'http_code' => 200,
+            'response_headers' => ['Content-Length: 7'],
+        ]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('GET', 'https://api.example.com/data');
+        $response->getHeaders();
+
+        $metrics = $this->collectMetrics();
+        self::assertArrayHasKey('http.client.response.body.size', $metrics);
+
+        $points = [...$metrics['http.client.response.body.size']->data->dataPoints];
+        self::assertSame(7, $points[0]->sum);
+    }
+
+    public function testRequestBodySizeFromContentLengthHeader(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('', ['http_code' => 204]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('POST', 'https://api.example.com/items', [
+            'body' => '{"name":"foo"}',
+            'headers' => ['Content-Length' => '14'],
+        ]);
+        $response->getStatusCode();
+
+        $metrics = $this->collectMetrics();
+        self::assertArrayHasKey('http.client.request.body.size', $metrics);
+
+        $points = [...$metrics['http.client.request.body.size']->data->dataPoints];
+        self::assertSame(14, $points[0]->sum);
+    }
+
+    public function testRequestBodySizeFromStringBodyWhenNoHeader(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('', ['http_code' => 204]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('POST', 'https://api.example.com/items', [
+            'body' => 'hello',
+        ]);
+        $response->getStatusCode();
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['http.client.request.body.size']->data->dataPoints];
+        self::assertSame(5, $points[0]->sum);
+    }
+
+    public function testNoRequestBodySizeWhenNothingMeasurable(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('GET', 'https://api.example.com/data');
+        $response->getStatusCode();
+
+        $metrics = $this->collectMetrics();
+        self::assertArrayNotHasKey('http.client.request.body.size', $metrics);
+    }
+
+    public function testErrorStatusCodeRecordedWithoutErrorType(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('not found', ['http_code' => 404]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('GET', 'https://api.example.com/missing');
+        $response->getStatusCode();
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['http.client.request.duration']->data->dataPoints];
+        $attr = $points[0]->attributes->toArray();
+
+        self::assertSame(404, $attr['http.response.status_code']);
+        // A 4xx response is a successful transport: we don't synthesize error.type here.
+        // Users can alert on status_code >= 400 in Grafana.
+        self::assertArrayNotHasKey('error.type', $attr);
+    }
+
+    public function testTransportFailureAddsErrorType(): void
+    {
+        $mockClient = new MockHttpClient(function () {
+            throw new \RuntimeException('connection refused');
+        });
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        try {
+            $response = $client->request('GET', 'https://api.example.com/data');
+            $response->getContent();
+            self::fail('Expected exception');
+        } catch (\Throwable) {
+        }
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['http.client.request.duration']->data->dataPoints];
+        self::assertSame('RuntimeException', $points[0]->attributes->toArray()['error.type']);
+    }
+
+    public function testExcludedHostSkipsMetrics(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test', ['api.example.com']);
+
+        $response = $client->request('GET', 'https://api.example.com/data');
+        $response->getStatusCode();
+
+        self::assertSame([], $this->collectMetrics());
+    }
+
+    public function testOtlpEndpointAutoExcluded(): void
+    {
+        $_SERVER['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'https://otlp.example.com';
+
+        try {
+            $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+            $client = new MeteredHttpClient($mockClient, 'test');
+
+            $response = $client->request('POST', 'https://otlp.example.com/v1/metrics');
+            $response->getStatusCode();
+
+            self::assertSame([], $this->collectMetrics());
+        } finally {
+            unset($_SERVER['OTEL_EXPORTER_OTLP_ENDPOINT']);
+        }
+    }
+
+    public function testResponseReturnsMeteredResponse(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('GET', 'https://api.example.com/data');
+
+        self::assertInstanceOf(MeteredResponse::class, $response);
+    }
+
+    public function testWithOptionsReturnsNewInstance(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $clone = $client->withOptions(['timeout' => 10]);
+
+        self::assertInstanceOf(MeteredHttpClient::class, $clone);
+        self::assertNotSame($client, $clone);
+    }
+
+    public function testStreamUnwrapsMeteredResponses(): void
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('a', ['http_code' => 200]),
+            new MockResponse('b', ['http_code' => 200]),
+        ]);
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $r1 = $client->request('GET', 'https://api.example.com/a');
+        $r2 = $client->request('GET', 'https://api.example.com/b');
+
+        $chunks = 0;
+        foreach ($client->stream([$r1, $r2]) as $response => $chunk) {
+            if ($chunk->isLast()) {
+                $chunks++;
+            }
+        }
+
+        self::assertSame(2, $chunks);
+    }
+
+    public function testResetClearsCachedMeter(): void
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('ok', ['http_code' => 200]),
+            new MockResponse('ok', ['http_code' => 200]),
+        ]);
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $client->request('GET', 'https://api.example.com/a')->getStatusCode();
+        $client->reset();
+        $client->request('GET', 'https://api.example.com/b')->getStatusCode();
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['http.client.request.duration']->data->dataPoints];
+        $total = 0;
+        foreach ($points as $p) {
+            $total += $p->count;
+        }
+        self::assertSame(2, $total);
+    }
+}

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -360,4 +360,36 @@ final class MeteredHttpClientTest extends TestCase
         $requestBodySize->setAccessible(true);
         $requestBodySize->setValue($client, $broken);
     }
+
+    public function testInFlightReentrantCallSkipsMetrics(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $reflection = new \ReflectionClass($client);
+        $inFlight = $reflection->getProperty('inFlight');
+        $inFlight->setAccessible(true);
+        $inFlight->setValue($client, true);
+
+        $response = $client->request('GET', 'https://api.example.com/data');
+        $response->getStatusCode();
+
+        self::assertNotInstanceOf(MeteredResponse::class, $response);
+        self::assertSame([], $this->collectMetrics());
+    }
+
+    public function testResetClearsInFlightFlag(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $reflection = new \ReflectionClass($client);
+        $inFlight = $reflection->getProperty('inFlight');
+        $inFlight->setAccessible(true);
+        $inFlight->setValue($client, true);
+
+        $client->reset();
+
+        self::assertFalse($inFlight->getValue($client));
+    }
 }

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -214,13 +214,37 @@ final class MeteredHttpClientTest extends TestCase
         $r2 = $client->request('GET', 'https://api.example.com/b');
 
         $chunks = 0;
+        $yielded = [];
         foreach ($client->stream([$r1, $r2]) as $response => $chunk) {
+            $yielded[] = $response;
             if ($chunk->isLast()) {
                 $chunks++;
             }
         }
 
         self::assertSame(2, $chunks);
+        foreach ($yielded as $response) {
+            self::assertInstanceOf(MeteredResponse::class, $response);
+        }
+    }
+
+    public function testStreamReKeysChunksToMeteredResponseForDecoratorsAbove(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('ok', ['http_code' => 200]));
+        $client = new MeteredHttpClient($mockClient, 'test');
+
+        $response = $client->request('GET', 'https://api.example.com/');
+
+        // Decorators above MeteredHttpClient (e.g. RetryableHttpClient) hand
+        // back the wrapper they received. They must be able to look it up in
+        // the stream output, otherwise Symfony's AsyncResponse throws
+        // "UnexpectedValueException: Object not found".
+        foreach ($client->stream($response) as $yielded => $chunk) {
+            self::assertSame($response, $yielded);
+            if ($chunk->isLast()) {
+                break;
+            }
+        }
     }
 
     public function testResetClearsCachedMeter(): void

--- a/tests/HttpClient/MeteredResponseTest.php
+++ b/tests/HttpClient/MeteredResponseTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\HttpClient;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Traceway\OpenTelemetryBundle\HttpClient\MeteredHttpClient;
+use Traceway\OpenTelemetryBundle\HttpClient\MeteredResponse;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+final class MeteredResponseTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownOTel();
+    }
+
+    public function testGetHeadersFinalisesWithBodySize(): void
+    {
+        $body = str_repeat('x', 123);
+        $response = $this->wrap(new MockResponse($body, [
+            'http_code' => 200,
+            'response_headers' => ['Content-Length: 123'],
+        ]));
+
+        $headers = $response->getHeaders();
+
+        self::assertArrayHasKey('content-length', $headers);
+
+        $bodySize = [...$this->collectMetrics()['http.client.response.body.size']->data->dataPoints][0]->sum;
+        self::assertSame(123, $bodySize);
+    }
+
+    public function testGetHeadersFinalisesWithoutBodySizeWhenContentLengthMissing(): void
+    {
+        $response = $this->wrap(new MockResponse('ok', ['http_code' => 200]));
+
+        $response->getHeaders();
+
+        $metrics = $this->collectMetrics();
+        self::assertArrayNotHasKey('http.client.response.body.size', $metrics);
+    }
+
+    public function testGetHeadersFinalisesWithErrorOnTransportFailure(): void
+    {
+        $response = $this->wrap(new MockResponse('', [
+            'http_code' => 0,
+            'error' => 'connection refused',
+        ]));
+
+        try {
+            $response->getHeaders();
+            self::fail('Expected TransportException');
+        } catch (TransportException) {
+        }
+
+        $attr = [...$this->collectMetrics()['http.client.request.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertArrayHasKey('error.type', $attr);
+    }
+
+    public function testGetContentFinalisesWithBodySize(): void
+    {
+        $response = $this->wrap(new MockResponse('hello world', ['http_code' => 200]));
+
+        $content = $response->getContent();
+
+        self::assertSame('hello world', $content);
+
+        $bodySize = [...$this->collectMetrics()['http.client.response.body.size']->data->dataPoints][0]->sum;
+        self::assertSame(11, $bodySize);
+    }
+
+    public function testGetContentFinalisesWithErrorOnFailure(): void
+    {
+        $response = $this->wrap(new MockResponse('', [
+            'http_code' => 0,
+            'error' => 'transport down',
+        ]));
+
+        try {
+            $response->getContent();
+            self::fail('Expected TransportException');
+        } catch (TransportException) {
+        }
+
+        $attr = [...$this->collectMetrics()['http.client.request.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertArrayHasKey('error.type', $attr);
+    }
+
+    public function testToArrayFinalisesOnSuccess(): void
+    {
+        $response = $this->wrap(new MockResponse(json_encode(['ok' => true]), [
+            'http_code' => 200,
+            'response_headers' => ['Content-Type: application/json'],
+        ]));
+
+        $array = $response->toArray();
+
+        self::assertSame(['ok' => true], $array);
+        self::assertArrayHasKey('http.client.request.duration', $this->collectMetrics());
+    }
+
+    public function testToArrayFinalisesWithErrorOnTransportFailure(): void
+    {
+        $response = $this->wrap(new MockResponse('', [
+            'http_code' => 0,
+            'error' => 'down',
+        ]));
+
+        try {
+            $response->toArray();
+            self::fail('Expected exception');
+        } catch (\Throwable) {
+        }
+
+        $attr = [...$this->collectMetrics()['http.client.request.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertArrayHasKey('error.type', $attr);
+    }
+
+    public function testCancelMarksResponseFinalisedSilently(): void
+    {
+        $response = $this->wrap(new MockResponse('ok', ['http_code' => 200]));
+
+        $response->cancel();
+
+        // No metric emitted because the response is marked finalized before any record call.
+        self::assertSame([], $this->collectMetrics());
+    }
+
+    public function testGetInfoIsPassThrough(): void
+    {
+        $response = $this->wrap(new MockResponse('ok', ['http_code' => 201]));
+
+        // Trigger the underlying HTTP call so MockResponse populates info.
+        $response->getStatusCode();
+
+        self::assertSame(201, $response->getInfo('http_code'));
+    }
+
+    public function testGetInnerResponseExposesUnwrapped(): void
+    {
+        $response = $this->wrap(new MockResponse('ok', ['http_code' => 200]));
+
+        $inner = $response->getInnerResponse();
+        self::assertInstanceOf(ResponseInterface::class, $inner);
+        self::assertNotInstanceOf(MeteredResponse::class, $inner);
+    }
+
+    public function testStatusCodeFinalisesOnce(): void
+    {
+        $response = $this->wrap(new MockResponse('ok', ['http_code' => 200]));
+
+        $response->getStatusCode();
+        $response->getStatusCode();
+
+        $points = [...$this->collectMetrics()['http.client.request.duration']->data->dataPoints];
+        self::assertSame(1, $points[0]->count);
+    }
+
+    public function testDestructorFinalisesPendingResponse(): void
+    {
+        $response = $this->wrap(new MockResponse('ok', ['http_code' => 200]));
+        unset($response);
+
+        // Destructor calls finalize via the underlying response status — at least one duration point is recorded.
+        self::assertArrayHasKey('http.client.request.duration', $this->collectMetrics());
+    }
+
+    private function wrap(MockResponse $mock): MeteredResponse
+    {
+        $client = new MeteredHttpClient(new MockHttpClient($mock), 'test');
+
+        $response = $client->request('GET', 'https://api.example.com/x');
+        self::assertInstanceOf(MeteredResponse::class, $response);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Adds OpenTelemetry metrics for outgoing requests through the Symfony HttpClient, sibling of
  `TraceableHttpClient` on the trace side. Off by default.                                    
  
  ## Instruments                                                                              
                  
  - `http.client.request.duration` (Histogram, `s`) — semconv Stable                          
  - `http.client.request.body.size` (Histogram, `By`) — Development
  - `http.client.response.body.size` (Histogram, `By`) — Development                          
                  
  Attributes: `http.request.method`, `server.address`, `server.port`, `url.scheme`,           
  `http.response.status_code` on response, `error.type` on transport failure (4xx/5xx are not
  synthesised as errors — alert on `status_code >= 400` instead).                             
                  
  ## Config                                                                                   
  
  ```yaml                                                                                     
  open_telemetry: 
      metrics:
          enabled: true
          http_client:
              enabled: true
              excluded_hosts: []   # OTLP endpoint is auto-excluded                           
  ```                                                                                             
  Behaviour                                                                                   
                                                                                              
  - Decorator pattern: MeteredHttpClient wraps any HttpClientInterface, MeteredResponse       
  finalises metrics lazily when the caller reads status/headers/content.
  - Same OTLP-endpoint auto-exclusion and re-entrance guard as the trace decorator — the OTLP 
  exporter using this client doesn't recurse.                                                 
  
  Notes                                                                                       
                  
  - Review patterns from #27 applied up-front: error.type uses FQCN with parent-class fallback
   for anonymous classes, duration histogram declares second-based buckets, every recording
  path is wrapped in a swallowing try/catch (request-body, response, failure) so a broken     
  meter provider cannot mask the original transport exception. inFlight is reset in a finally.
  - Introduces Util\ErrorTypeResolver for the FQCN/anonymous fallback. The same class is
  duplicated by the parallel http-server and doctrine PRs; whichever merges first lands it on 
  master, the others rebase clean.
  - 11 new HttpClient tests + 4 ErrorTypeResolver tests, suite green.