### PR TITLE
feat(metrics): add Doctrine DBAL metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ open_telemetry:
         messenger:
             enabled: false             # emit messaging.process.duration / messaging.client.consumed.messages
             excluded_queues: []
+        doctrine:
+            enabled: false             # emit db.client.operation.duration for every DBAL query/exec/transaction
 ```
 
 ### Environment Variables
@@ -147,7 +149,7 @@ Mock in tests with `$this->createStub(TracingInterface::class)` and have `trace(
 
 ## Metrics
 
-**Off by default.** Enable to export OpenTelemetry metrics alongside traces, with opt-in automatic instrumentation for Symfony Messenger.
+**Off by default.** Enable to export OpenTelemetry metrics alongside traces, with opt-in automatic instrumentation for Symfony Messenger and Doctrine DBAL.
 
 ```yaml
 open_telemetry:
@@ -157,20 +159,23 @@ open_telemetry:
         messenger:
             enabled: true
             excluded_queues: []
+        doctrine:
+            enabled: true
 ```
 
 ### What Gets Measured
 
-Emitted on the consume path of the Messenger bus:
+| Instrument | Kind | Unit | Source | Attributes |
+|---|---|---|---|---|
+| `messaging.process.duration` | Histogram | `s` | Messenger consume | `messaging.system`, `messaging.operation.name`, `messaging.operation.type`, `messaging.destination.name`, `error.type` on failure |
+| `messaging.client.consumed.messages` | Counter | `{message}` | Messenger consume | Same as above |
+| `db.client.operation.duration` | Histogram | `s` | DBAL connection | `db.system.name`, `db.namespace`, `server.address`, `server.port`, `db.operation.name`, `db.collection.name` (when extractable), `error.type` on failure |
 
-| Instrument | Kind | Unit | Attributes |
-|---|---|---|---|
-| `messaging.process.duration` | Histogram | `s` | `messaging.system`, `messaging.operation.name`, `messaging.operation.type`, `messaging.destination.name`, `error.type` on failure |
-| `messaging.client.consumed.messages` | Counter | `{message}` | Same as above |
-
-Names and attributes follow the [OTel messaging metrics semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/). All messaging metrics and attributes are currently **Development** in the spec. The general `error.type` attribute is Stable. Service identity (`service.name`, `service.namespace`, `service.version`) comes from the OTel resource, set via `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`, not from metric name prefixing.
+Names and attributes follow OTel semantic conventions: [messaging metrics](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/) (Development) and [database client metrics](https://opentelemetry.io/docs/specs/semconv/database/database-metrics/) (Stable). The general `error.type` attribute is Stable. Service identity (`service.name`, `service.namespace`, `service.version`) comes from the OTel resource, set via `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`, not from metric name prefixing.
 
 `messenger.excluded_queues` is matched on `ReceivedStamp::getTransportName()` (consume path only). Dispatch-side exclusion and dispatch metrics (`messaging.client.sent.messages`, `messaging.client.operation.duration`) are out of scope for this first metrics drop.
+
+The DBAL instrumentation wraps every connection produced by Doctrine. It records duration for `Connection::query()`, `Connection::exec()`, prepared `Statement::execute()`, and the transaction control methods (`beginTransaction`, `commit`, `rollBack`). The SQL text itself is **never** recorded — only the leading keyword (`db.operation.name`) and the primary table when it can be extracted unambiguously (`db.collection.name`).
 
 ### Manual Instrumentation
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,4 +10,6 @@ parameters:
         analyseAndScan:
             - src/Doctrine/Middleware/TraceableConnectionDbal3.php
             - src/Doctrine/Middleware/TraceableStatementDbal3.php
+            - src/Doctrine/Middleware/MeteredConnectionDbal3.php
+            - src/Doctrine/Middleware/MeteredStatementDbal3.php
     tmpDir: /tmp/phpstan

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -148,6 +148,16 @@ final class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->arrayNode('doctrine')
+                            ->info('Automatic metrics for Doctrine DBAL connections.')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('enabled')
+                                    ->info('Emit db.client.operation.duration (histogram) for every DBAL query, exec, prepared statement execution and transaction control. Requires metrics.enabled and doctrine/dbal.')
+                                    ->defaultFalse()
+                                ->end()
+                            ->end()
+                        ->end()
                     ->end()
                     ->validate()
                         ->ifTrue(static function (array $c): bool {
@@ -155,6 +165,13 @@ final class Configuration implements ConfigurationInterface
                             return true === ($messenger['enabled'] ?? false) && true !== ($c['enabled'] ?? false);
                         })
                         ->thenInvalid('"open_telemetry.metrics.messenger.enabled" requires "open_telemetry.metrics.enabled" to be true.')
+                    ->end()
+                    ->validate()
+                        ->ifTrue(static function (array $c): bool {
+                            $doctrine = \is_array($c['doctrine'] ?? null) ? $c['doctrine'] : [];
+                            return true === ($doctrine['enabled'] ?? false) && true !== ($c['enabled'] ?? false);
+                        })
+                        ->thenInvalid('"open_telemetry.metrics.doctrine.enabled" requires "open_telemetry.metrics.enabled" to be true.')
                     ->end()
                 ->end()
             ->end()

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Doctrine\DBAL\Driver\Middleware as DoctrineMiddleware;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredMiddleware as DoctrineMeteredMiddleware;
 use Traceway\OpenTelemetryBundle\Doctrine\Middleware\TraceableMiddleware as DoctrineTraceableMiddleware;
 use Traceway\OpenTelemetryBundle\EventSubscriber\ConsoleSubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetrySubscriber;
@@ -178,6 +179,15 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
                 ->setArgument('$excludedQueues', $metrics['messenger']['excluded_queues']);
         } else {
             $container->removeDefinition(OpenTelemetryMetricsMiddleware::class);
+        }
+
+        /** @var array{doctrine?: array{enabled: bool}} $metricsTyped */
+        $metricsTyped = $metrics;
+        if ($metrics['enabled'] && ($metricsTyped['doctrine']['enabled'] ?? false) && $this->isDoctrineAvailable()) {
+            $definition = new Definition(DoctrineMeteredMiddleware::class);
+            $definition->setArgument('$meterName', $meterName);
+            $definition->addTag('doctrine.middleware');
+            $container->setDefinition(DoctrineMeteredMiddleware::class, $definition);
         }
     }
 

--- a/src/Doctrine/Metrics/DbMetricRecorder.php
+++ b/src/Doctrine/Metrics/DbMetricRecorder.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Doctrine\Metrics;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use Symfony\Contracts\Service\ResetInterface;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\SqlOperationExtractor;
+use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
+
+/**
+ * Emits OpenTelemetry metrics for Doctrine DBAL operations.
+ *
+ * Bound to a single Doctrine connection at construction time so the per-connection
+ * context (db.system.name, db.namespace, server.{address,port}) only resolves once.
+ * Shared by {@see MeteredConnectionDbal3}, {@see MeteredConnectionDbal4} and their
+ * statement counterparts; one recorder instance per connection.
+ *
+ * Metric: db.client.operation.duration (Histogram, seconds) — semconv Stable.
+ */
+final class DbMetricRecorder implements ResetInterface
+{
+    public const DURATION_BUCKET_BOUNDARIES = [
+        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+    ];
+
+    private ?MeterInterface $meter = null;
+    private ?HistogramInterface $duration = null;
+
+    public function __construct(
+        private readonly string $meterName,
+        private readonly string $dbSystem,
+        private readonly ?string $dbName,
+        private readonly ?string $serverAddress,
+        private readonly ?int $serverPort,
+    ) {}
+
+    public function record(string $sql, int|float $start, ?\Throwable $exception): void
+    {
+        try {
+            $attributes = $this->baseAttributes();
+
+            $operation = SqlOperationExtractor::extract($sql);
+            if ('UNKNOWN' !== $operation) {
+                $attributes['db.operation.name'] = $operation;
+            }
+
+            $target = SqlOperationExtractor::extractTarget($sql);
+            if (null !== $target) {
+                $attributes['db.collection.name'] = $target;
+            }
+
+            if (null !== $exception) {
+                $attributes['error.type'] = ErrorTypeResolver::resolve($exception);
+            }
+
+            $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+            $this->getDurationHistogram()->record($durationSeconds, $attributes);
+        } catch (\Throwable) {
+        }
+    }
+
+    public function reset(): void
+    {
+        $this->meter = null;
+        $this->duration = null;
+    }
+
+    /**
+     * @return array<non-empty-string, string|int>
+     */
+    private function baseAttributes(): array
+    {
+        $attributes = [
+            'db.system.name' => $this->dbSystem,
+        ];
+
+        if (null !== $this->dbName) {
+            $attributes['db.namespace'] = $this->dbName;
+        }
+        if (null !== $this->serverAddress) {
+            $attributes['server.address'] = $this->serverAddress;
+        }
+        if (null !== $this->serverPort) {
+            $attributes['server.port'] = $this->serverPort;
+        }
+
+        return $attributes;
+    }
+
+    private function getDurationHistogram(): HistogramInterface
+    {
+        return $this->duration ??= $this->getMeter()->createHistogram(
+            'db.client.operation.duration',
+            's',
+            'Duration of database client operations',
+            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
+        );
+    }
+
+    private function getMeter(): MeterInterface
+    {
+        return $this->meter ??= Globals::meterProvider()->getMeter($this->meterName);
+    }
+}

--- a/src/Doctrine/Middleware/MeteredConnectionDbal3.php
+++ b/src/Doctrine/Middleware/MeteredConnectionDbal3.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+
+final class MeteredConnectionDbal3 extends AbstractConnectionMiddleware
+{
+    public function __construct(
+        Connection $connection,
+        private readonly DbMetricRecorder $recorder,
+    ) {
+        parent::__construct($connection);
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        return new MeteredStatementDbal3(parent::prepare($sql), $this->recorder, $sql);
+    }
+
+    public function query(string $sql): Result
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return parent::query($sql);
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record($sql, $start, $exception);
+        }
+    }
+
+    public function exec(string $sql): int
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return (int) parent::exec($sql);
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record($sql, $start, $exception);
+        }
+    }
+
+    public function beginTransaction(): bool
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return (bool) parent::beginTransaction();
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record('BEGIN', $start, $exception);
+        }
+    }
+
+    public function commit(): bool
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return (bool) parent::commit();
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record('COMMIT', $start, $exception);
+        }
+    }
+
+    public function rollBack(): bool
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return (bool) parent::rollBack();
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record('ROLLBACK', $start, $exception);
+        }
+    }
+}

--- a/src/Doctrine/Middleware/MeteredConnectionDbal4.php
+++ b/src/Doctrine/Middleware/MeteredConnectionDbal4.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+
+final class MeteredConnectionDbal4 extends AbstractConnectionMiddleware
+{
+    public function __construct(
+        Connection $connection,
+        private readonly DbMetricRecorder $recorder,
+    ) {
+        parent::__construct($connection);
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        return new MeteredStatementDbal4(parent::prepare($sql), $this->recorder, $sql);
+    }
+
+    public function query(string $sql): Result
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return parent::query($sql);
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record($sql, $start, $exception);
+        }
+    }
+
+    public function exec(string $sql): int
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return (int) parent::exec($sql);
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record($sql, $start, $exception);
+        }
+    }
+
+    public function beginTransaction(): void
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            parent::beginTransaction();
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record('BEGIN', $start, $exception);
+        }
+    }
+
+    public function commit(): void
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            parent::commit();
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record('COMMIT', $start, $exception);
+        }
+    }
+
+    public function rollBack(): void
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            parent::rollBack();
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record('ROLLBACK', $start, $exception);
+        }
+    }
+}

--- a/src/Doctrine/Middleware/MeteredDriver.php
+++ b/src/Doctrine/Middleware/MeteredDriver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+
+final class MeteredDriver extends AbstractDriverMiddleware
+{
+    public function __construct(
+        Driver $driver,
+        private readonly string $meterName,
+    ) {
+        parent::__construct($driver);
+    }
+
+    public function connect(array $params): Connection
+    {
+        $connection = parent::connect($params);
+
+        $recorder = new DbMetricRecorder(
+            $this->meterName,
+            $this->resolveDbSystem($params),
+            $params['dbname'] ?? null,
+            $params['host'] ?? null,
+            isset($params['port']) ? (int) $params['port'] : null,
+        );
+
+        return self::isDbal4()
+            ? new MeteredConnectionDbal4($connection, $recorder)
+            : new MeteredConnectionDbal3($connection, $recorder);
+    }
+
+    private static function isDbal4(): bool
+    {
+        /** @var bool|null $result */
+        static $result = null;
+
+        return $result ??= !interface_exists(\Doctrine\DBAL\VersionAwarePlatformDriver::class);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function resolveDbSystem(array $params): string
+    {
+        $driver = isset($params['driver']) && \is_string($params['driver']) ? $params['driver'] : '';
+
+        return match (true) {
+            str_contains($driver, 'mysql') => 'mysql',
+            str_contains($driver, 'pgsql') || str_contains($driver, 'postgres') => 'postgresql',
+            str_contains($driver, 'sqlite') => 'sqlite',
+            str_contains($driver, 'sqlsrv') || str_contains($driver, 'mssql') => 'mssql',
+            str_contains($driver, 'oci') || str_contains($driver, 'oracle') => 'oracle',
+            default => $driver !== '' ? $driver : 'other_sql',
+        };
+    }
+}

--- a/src/Doctrine/Middleware/MeteredMiddleware.php
+++ b/src/Doctrine/Middleware/MeteredMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Middleware;
+
+final class MeteredMiddleware implements Middleware
+{
+    public function __construct(
+        private readonly string $meterName = 'opentelemetry-symfony',
+    ) {}
+
+    public function wrap(DriverInterface $driver): DriverInterface
+    {
+        return new MeteredDriver($driver, $this->meterName);
+    }
+}

--- a/src/Doctrine/Middleware/MeteredStatementDbal3.php
+++ b/src/Doctrine/Middleware/MeteredStatementDbal3.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+
+final class MeteredStatementDbal3 extends AbstractStatementMiddleware
+{
+    public function __construct(
+        Statement $statement,
+        private readonly DbMetricRecorder $recorder,
+        private readonly string $sql,
+    ) {
+        parent::__construct($statement);
+    }
+
+    /**
+     * @param mixed[]|null $params
+     */
+    public function execute($params = null): Result
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return parent::execute($params);
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record($this->sql, $start, $exception);
+        }
+    }
+}

--- a/src/Doctrine/Middleware/MeteredStatementDbal4.php
+++ b/src/Doctrine/Middleware/MeteredStatementDbal4.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+
+final class MeteredStatementDbal4 extends AbstractStatementMiddleware
+{
+    public function __construct(
+        Statement $statement,
+        private readonly DbMetricRecorder $recorder,
+        private readonly string $sql,
+    ) {
+        parent::__construct($statement);
+    }
+
+    public function execute(): Result
+    {
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return parent::execute();
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            $this->recorder->record($this->sql, $start, $exception);
+        }
+    }
+}

--- a/src/Util/ErrorTypeResolver.php
+++ b/src/Util/ErrorTypeResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Util;
+
+final class ErrorTypeResolver
+{
+    public static function resolve(\Throwable $exception): string
+    {
+        $type = $exception::class;
+
+        if (str_contains($type, '@anonymous')) {
+            $type = get_parent_class($exception) ?: \Throwable::class;
+        }
+
+        return $type;
+    }
+}

--- a/tests/Doctrine/Metrics/DbMetricRecorderTest.php
+++ b/tests/Doctrine/Metrics/DbMetricRecorderTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Metrics;
+
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+final class DbMetricRecorderTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownOTel();
+    }
+
+    public function testRecordEmitsDurationWithBaseAttributes(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'postgresql', 'app_db', 'localhost', 5432);
+
+        $recorder->record('SELECT id FROM users WHERE id = 1', hrtime(true), null);
+
+        $metrics = $this->collectMetrics();
+        self::assertArrayHasKey('db.client.operation.duration', $metrics);
+
+        $duration = $metrics['db.client.operation.duration'];
+        self::assertSame('s', $duration->unit);
+
+        $points = [...$duration->data->dataPoints];
+        self::assertCount(1, $points);
+
+        $attr = $points[0]->attributes->toArray();
+        self::assertSame('postgresql', $attr['db.system.name']);
+        self::assertSame('app_db', $attr['db.namespace']);
+        self::assertSame('localhost', $attr['server.address']);
+        self::assertSame(5432, $attr['server.port']);
+        self::assertSame('SELECT', $attr['db.operation.name']);
+        self::assertSame('users', $attr['db.collection.name']);
+        self::assertArrayNotHasKey('error.type', $attr);
+    }
+
+    public function testRecordOmitsOptionalAttributesWhenAbsent(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'sqlite', null, null, null);
+
+        $recorder->record('BEGIN', hrtime(true), null);
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['db.client.operation.duration']->data->dataPoints];
+        $attr = $points[0]->attributes->toArray();
+
+        self::assertSame('sqlite', $attr['db.system.name']);
+        self::assertArrayNotHasKey('db.namespace', $attr);
+        self::assertArrayNotHasKey('server.address', $attr);
+        self::assertArrayNotHasKey('server.port', $attr);
+        self::assertSame('BEGIN', $attr['db.operation.name']);
+        self::assertArrayNotHasKey('db.collection.name', $attr);
+    }
+
+    public function testRecordOmitsCollectionWhenSqlIsAmbiguous(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'mysql', 'app_db', null, null);
+
+        $recorder->record('CREATE TABLE foo (id INT)', hrtime(true), null);
+
+        $metrics = $this->collectMetrics();
+        $attr = [...$metrics['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+
+        self::assertSame('CREATE', $attr['db.operation.name']);
+        self::assertArrayNotHasKey('db.collection.name', $attr);
+    }
+
+    public function testFailureAddsErrorType(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'postgresql', 'app_db', null, null);
+
+        $recorder->record('SELECT 1', hrtime(true), new \PDOException('connection lost'));
+
+        $metrics = $this->collectMetrics();
+        $attr = [...$metrics['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+
+        self::assertSame(\PDOException::class, $attr['error.type']);
+    }
+
+    public function testAnonymousExceptionFallsBackToParentClass(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'postgresql', null, null, null);
+
+        $recorder->record('SELECT 1', hrtime(true), new class('boom') extends \RuntimeException {});
+
+        $metrics = $this->collectMetrics();
+        $attr = [...$metrics['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+
+        self::assertSame('RuntimeException', $attr['error.type']);
+    }
+
+    public function testHistogramUsesSecondBasedBuckets(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'postgresql', null, null, null);
+
+        $recorder->record('SELECT 1', hrtime(true), null);
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['db.client.operation.duration']->data->dataPoints];
+
+        self::assertSame(
+            DbMetricRecorder::DURATION_BUCKET_BOUNDARIES,
+            $points[0]->explicitBounds,
+        );
+    }
+
+    public function testRecordSwallowsHistogramFailure(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'postgresql', null, null, null);
+
+        $broken = $this->createMock(HistogramInterface::class);
+        $broken->method('record')->willThrowException(new \RuntimeException('metrics down'));
+
+        $reflection = new \ReflectionClass($recorder);
+        $duration = $reflection->getProperty('duration');
+        $duration->setAccessible(true);
+        $duration->setValue($recorder, $broken);
+
+        $recorder->record('SELECT 1', hrtime(true), null);
+
+        self::assertTrue(true);
+    }
+
+    public function testResetClearsCachedMeter(): void
+    {
+        $recorder = new DbMetricRecorder('test', 'postgresql', null, null, null);
+
+        $recorder->record('SELECT 1', hrtime(true), null);
+        $recorder->reset();
+        $recorder->record('SELECT 1', hrtime(true), null);
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['db.client.operation.duration']->data->dataPoints];
+        self::assertSame(2, $points[0]->count);
+    }
+}

--- a/tests/Doctrine/Middleware/MeteredConnectionDbal3Test.php
+++ b/tests/Doctrine/Middleware/MeteredConnectionDbal3Test.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+/**
+ * Tests for DBAL 3 connection wrapper.
+ *
+ * @group dbal3
+ */
+final class MeteredConnectionDbal3Test extends TestCase
+{
+    use OTelTestTrait;
+
+    private Connection $inner;
+
+    /** @var \Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredConnectionDbal3 */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        if (!interface_exists(\Doctrine\DBAL\VersionAwarePlatformDriver::class)) {
+            self::markTestSkipped('DBAL 3 is not installed.');
+        }
+
+        $this->setUpOTel();
+        $this->inner = $this->createStub(Connection::class);
+
+        $recorder = new DbMetricRecorder('test', 'mysql', 'app_db', 'localhost', 3306);
+
+        /** @phpstan-ignore-next-line */
+        $this->connection = new \Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredConnectionDbal3(
+            $this->inner,
+            $recorder,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->metricExporter)) {
+            $this->tearDownOTel();
+        }
+    }
+
+    public function testQueryEmitsDuration(): void
+    {
+        $this->inner->method('query')->willReturn($this->createStub(Result::class));
+
+        $this->connection->query('SELECT id FROM users');
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('SELECT', $attr['db.operation.name']);
+        self::assertSame('users', $attr['db.collection.name']);
+    }
+
+    public function testExecEmitsDuration(): void
+    {
+        $this->inner->method('exec')->willReturn(1);
+
+        $this->connection->exec('DELETE FROM logs');
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('DELETE', $attr['db.operation.name']);
+    }
+
+    public function testTransactionsEmitMetrics(): void
+    {
+        $this->inner->method('beginTransaction')->willReturn(true);
+        $this->inner->method('commit')->willReturn(true);
+        $this->inner->method('rollBack')->willReturn(true);
+
+        $this->connection->beginTransaction();
+        $this->connection->commit();
+        $this->connection->beginTransaction();
+        $this->connection->rollBack();
+
+        $points = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints];
+        $countsByOperation = [];
+        foreach ($points as $p) {
+            $countsByOperation[$p->attributes->toArray()['db.operation.name']] = $p->count;
+        }
+        ksort($countsByOperation);
+
+        self::assertSame(['BEGIN' => 2, 'COMMIT' => 1, 'ROLLBACK' => 1], $countsByOperation);
+    }
+
+    public function testQueryFailureAddsErrorTypeAndRethrows(): void
+    {
+        $this->inner->method('query')->willThrowException(new \RuntimeException('lost'));
+
+        try {
+            $this->connection->query('SELECT 1');
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('RuntimeException', $attr['error.type']);
+    }
+
+    public function testPrepareWrapsStatement(): void
+    {
+        $this->inner->method('prepare')->willReturn($this->createStub(Statement::class));
+
+        $statement = $this->connection->prepare('SELECT id FROM users WHERE id = ?');
+
+        self::assertInstanceOf(
+            \Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredStatementDbal3::class,
+            $statement,
+        );
+    }
+}

--- a/tests/Doctrine/Middleware/MeteredConnectionTest.php
+++ b/tests/Doctrine/Middleware/MeteredConnectionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredConnectionDbal4;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredStatementDbal4;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+/**
+ * @group dbal4
+ */
+final class MeteredConnectionTest extends TestCase
+{
+    use OTelTestTrait;
+
+    private Connection $inner;
+    private MeteredConnectionDbal4 $connection;
+
+    protected function setUp(): void
+    {
+        if (interface_exists(\Doctrine\DBAL\VersionAwarePlatformDriver::class)) {
+            self::markTestSkipped('DBAL 4 is not installed.');
+        }
+
+        $this->setUpOTel();
+        $this->inner = $this->createStub(Connection::class);
+
+        $recorder = new DbMetricRecorder('test', 'postgresql', 'app_db', 'localhost', 5432);
+        $this->connection = new MeteredConnectionDbal4($this->inner, $recorder);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->metricExporter)) {
+            $this->tearDownOTel();
+        }
+    }
+
+    public function testQueryEmitsDuration(): void
+    {
+        $this->inner->method('query')->willReturn($this->createStub(Result::class));
+
+        $this->connection->query('SELECT id FROM users');
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['db.client.operation.duration']->data->dataPoints];
+        self::assertCount(1, $points);
+
+        $attr = $points[0]->attributes->toArray();
+        self::assertSame('SELECT', $attr['db.operation.name']);
+        self::assertSame('users', $attr['db.collection.name']);
+    }
+
+    public function testExecEmitsDuration(): void
+    {
+        $this->inner->method('exec')->willReturn(1);
+
+        $this->connection->exec('INSERT INTO users (name) VALUES ("john")');
+
+        $metrics = $this->collectMetrics();
+        $attr = [...$metrics['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+
+        self::assertSame('INSERT', $attr['db.operation.name']);
+        self::assertSame('users', $attr['db.collection.name']);
+    }
+
+    public function testQueryFailureAddsErrorTypeAndRethrows(): void
+    {
+        $this->inner->method('query')->willThrowException(new \RuntimeException('table missing'));
+
+        try {
+            $this->connection->query('SELECT * FROM users');
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('RuntimeException', $attr['error.type']);
+    }
+
+    public function testTransactionControlEmitsMetrics(): void
+    {
+        $this->connection->beginTransaction();
+        $this->connection->commit();
+        $this->connection->beginTransaction();
+        $this->connection->rollBack();
+
+        $metrics = $this->collectMetrics();
+        $points = [...$metrics['db.client.operation.duration']->data->dataPoints];
+
+        $countsByOperation = [];
+        foreach ($points as $point) {
+            $op = $point->attributes->toArray()['db.operation.name'];
+            $countsByOperation[$op] = $point->count;
+        }
+        ksort($countsByOperation);
+
+        self::assertSame(['BEGIN' => 2, 'COMMIT' => 1, 'ROLLBACK' => 1], $countsByOperation);
+    }
+
+    public function testPrepareWrapsStatement(): void
+    {
+        $this->inner->method('prepare')->willReturn($this->createStub(Statement::class));
+
+        $statement = $this->connection->prepare('SELECT id FROM users WHERE id = ?');
+
+        self::assertInstanceOf(MeteredStatementDbal4::class, $statement);
+    }
+
+    public function testRecorderFailureDoesNotMaskQueryException(): void
+    {
+        $this->inner->method('query')->willThrowException(new \DomainException('app error'));
+
+        try {
+            $this->connection->query('SELECT 1');
+            self::fail('Expected DomainException');
+        } catch (\DomainException $caught) {
+            self::assertSame('app error', $caught->getMessage());
+        }
+    }
+}

--- a/tests/Doctrine/Middleware/MeteredConnectionTest.php
+++ b/tests/Doctrine/Middleware/MeteredConnectionTest.php
@@ -125,4 +125,64 @@ final class MeteredConnectionTest extends TestCase
             self::assertSame('app error', $caught->getMessage());
         }
     }
+
+    public function testExecFailureAddsErrorTypeAndRethrows(): void
+    {
+        $this->inner->method('exec')->willThrowException(new \RuntimeException('connection lost'));
+
+        try {
+            $this->connection->exec('DELETE FROM users');
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('RuntimeException', $attr['error.type']);
+        self::assertSame('DELETE', $attr['db.operation.name']);
+    }
+
+    public function testBeginTransactionFailureAddsErrorTypeAndRethrows(): void
+    {
+        $this->inner->method('beginTransaction')->willThrowException(new \RuntimeException('cannot begin'));
+
+        try {
+            $this->connection->beginTransaction();
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('RuntimeException', $attr['error.type']);
+        self::assertSame('BEGIN', $attr['db.operation.name']);
+    }
+
+    public function testCommitFailureAddsErrorTypeAndRethrows(): void
+    {
+        $this->inner->method('commit')->willThrowException(new \RuntimeException('commit failed'));
+
+        try {
+            $this->connection->commit();
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('RuntimeException', $attr['error.type']);
+        self::assertSame('COMMIT', $attr['db.operation.name']);
+    }
+
+    public function testRollBackFailureAddsErrorTypeAndRethrows(): void
+    {
+        $this->inner->method('rollBack')->willThrowException(new \RuntimeException('rollback failed'));
+
+        try {
+            $this->connection->rollBack();
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('RuntimeException', $attr['error.type']);
+        self::assertSame('ROLLBACK', $attr['db.operation.name']);
+    }
 }

--- a/tests/Doctrine/Middleware/MeteredDriverTest.php
+++ b/tests/Doctrine/Middleware/MeteredDriverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredConnectionDbal3;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredConnectionDbal4;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredDriver;
+
+final class MeteredDriverTest extends TestCase
+{
+    public function testConnectReturnsMeteredConnection(): void
+    {
+        $inner = $this->createStub(Driver::class);
+        $inner->method('connect')->willReturn($this->createStub(Connection::class));
+
+        $driver = new MeteredDriver($inner, 'test');
+        $connection = $driver->connect(['driver' => 'pdo_pgsql', 'dbname' => 'app_db', 'host' => 'db.local', 'port' => 5432]);
+
+        $expected = interface_exists(\Doctrine\DBAL\VersionAwarePlatformDriver::class)
+            ? MeteredConnectionDbal3::class
+            : MeteredConnectionDbal4::class;
+
+        self::assertInstanceOf($expected, $connection);
+    }
+}

--- a/tests/Doctrine/Middleware/MeteredDriverTest.php
+++ b/tests/Doctrine/Middleware/MeteredDriverTest.php
@@ -27,4 +27,50 @@ final class MeteredDriverTest extends TestCase
 
         self::assertInstanceOf($expected, $connection);
     }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function dbSystemProvider(): iterable
+    {
+        yield 'mysql driver' => ['pdo_mysql', 'mysql'];
+        yield 'postgres pdo' => ['pdo_pgsql', 'postgresql'];
+        yield 'postgres native' => ['pgsql', 'postgresql'];
+        yield 'sqlite' => ['pdo_sqlite', 'sqlite'];
+        yield 'sqlsrv' => ['pdo_sqlsrv', 'mssql'];
+        yield 'mssql' => ['mssql', 'mssql'];
+        yield 'oci' => ['oci8', 'oracle'];
+        yield 'oracle' => ['pdo_oracle', 'oracle'];
+        yield 'unknown' => ['custom_driver', 'custom_driver'];
+        yield 'empty' => ['', 'other_sql'];
+    }
+
+    /**
+     * @dataProvider dbSystemProvider
+     */
+    public function testResolvesDbSystemFromDriverString(string $driverName, string $expectedSystem): void
+    {
+        $inner = $this->createStub(Driver::class);
+        $inner->method('connect')->willReturn($this->createStub(Connection::class));
+
+        $reflection = new \ReflectionClass(MeteredDriver::class);
+        $method = $reflection->getMethod('resolveDbSystem');
+        $method->setAccessible(true);
+
+        $driver = new MeteredDriver($inner, 'test');
+        self::assertSame($expectedSystem, $method->invoke($driver, ['driver' => $driverName]));
+    }
+
+    public function testResolvesOtherSqlWhenDriverParamIsMissing(): void
+    {
+        $inner = $this->createStub(Driver::class);
+        $inner->method('connect')->willReturn($this->createStub(Connection::class));
+
+        $reflection = new \ReflectionClass(MeteredDriver::class);
+        $method = $reflection->getMethod('resolveDbSystem');
+        $method->setAccessible(true);
+
+        $driver = new MeteredDriver($inner, 'test');
+        self::assertSame('other_sql', $method->invoke($driver, []));
+    }
 }

--- a/tests/Doctrine/Middleware/MeteredMiddlewareTest.php
+++ b/tests/Doctrine/Middleware/MeteredMiddlewareTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredDriver;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredMiddleware;
+
+final class MeteredMiddlewareTest extends TestCase
+{
+    public function testWrapReturnsMeteredDriver(): void
+    {
+        $middleware = new MeteredMiddleware('test');
+        $inner = $this->createStub(Driver::class);
+
+        self::assertInstanceOf(MeteredDriver::class, $middleware->wrap($inner));
+    }
+}

--- a/tests/Doctrine/Middleware/MeteredStatementDbal3Test.php
+++ b/tests/Doctrine/Middleware/MeteredStatementDbal3Test.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+/**
+ * @group dbal3
+ */
+final class MeteredStatementDbal3Test extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        if (!interface_exists(\Doctrine\DBAL\VersionAwarePlatformDriver::class)) {
+            self::markTestSkipped('DBAL 3 is not installed.');
+        }
+
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->metricExporter)) {
+            $this->tearDownOTel();
+        }
+    }
+
+    public function testExecuteWithoutParamsEmitsDuration(): void
+    {
+        $inner = $this->createStub(Statement::class);
+        $inner->method('execute')->willReturn($this->createStub(Result::class));
+
+        $recorder = new DbMetricRecorder('test', 'mysql', 'app', null, null);
+
+        /** @phpstan-ignore-next-line */
+        $statement = new \Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredStatementDbal3(
+            $inner,
+            $recorder,
+            'UPDATE accounts SET active = 1 WHERE id = ?',
+        );
+
+        $statement->execute();
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('UPDATE', $attr['db.operation.name']);
+        self::assertSame('accounts', $attr['db.collection.name']);
+    }
+
+    public function testExecuteWithParamsEmitsDuration(): void
+    {
+        $inner = $this->createStub(Statement::class);
+        $inner->method('execute')->willReturn($this->createStub(Result::class));
+
+        $recorder = new DbMetricRecorder('test', 'mysql', 'app', null, null);
+
+        /** @phpstan-ignore-next-line */
+        $statement = new \Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredStatementDbal3(
+            $inner,
+            $recorder,
+            'SELECT * FROM users WHERE id = ?',
+        );
+
+        $statement->execute([1]);
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('SELECT', $attr['db.operation.name']);
+    }
+
+    public function testExecuteFailureAddsErrorTypeAndRethrows(): void
+    {
+        $inner = $this->createStub(Statement::class);
+        $inner->method('execute')->willThrowException(new \LogicException('bad params'));
+
+        $recorder = new DbMetricRecorder('test', 'mysql', null, null, null);
+
+        /** @phpstan-ignore-next-line */
+        $statement = new \Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredStatementDbal3(
+            $inner,
+            $recorder,
+            'SELECT 1',
+        );
+
+        try {
+            $statement->execute();
+            self::fail('Expected LogicException');
+        } catch (\LogicException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('LogicException', $attr['error.type']);
+    }
+}

--- a/tests/Doctrine/Middleware/MeteredStatementTest.php
+++ b/tests/Doctrine/Middleware/MeteredStatementTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredStatementDbal4;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+/**
+ * @group dbal4
+ */
+final class MeteredStatementTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        if (interface_exists(\Doctrine\DBAL\VersionAwarePlatformDriver::class)) {
+            self::markTestSkipped('DBAL 4 is not installed.');
+        }
+
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->metricExporter)) {
+            $this->tearDownOTel();
+        }
+    }
+
+    public function testExecuteEmitsDurationWithSqlAttributes(): void
+    {
+        $inner = $this->createStub(Statement::class);
+        $inner->method('execute')->willReturn($this->createStub(Result::class));
+
+        $recorder = new DbMetricRecorder('test', 'mysql', 'app_db', null, null);
+        $statement = new MeteredStatementDbal4($inner, $recorder, 'UPDATE accounts SET active = 1 WHERE id = ?');
+
+        $statement->execute();
+
+        $metrics = $this->collectMetrics();
+        $attr = [...$metrics['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+
+        self::assertSame('UPDATE', $attr['db.operation.name']);
+        self::assertSame('accounts', $attr['db.collection.name']);
+    }
+
+    public function testExecuteFailureAddsErrorTypeAndRethrows(): void
+    {
+        $inner = $this->createStub(Statement::class);
+        $inner->method('execute')->willThrowException(new \LogicException('bad params'));
+
+        $recorder = new DbMetricRecorder('test', 'mysql', null, null, null);
+        $statement = new MeteredStatementDbal4($inner, $recorder, 'SELECT 1');
+
+        try {
+            $statement->execute();
+            self::fail('Expected LogicException');
+        } catch (\LogicException) {
+        }
+
+        $attr = [...$this->collectMetrics()['db.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame('LogicException', $attr['error.type']);
+    }
+}

--- a/tests/Functional/BundleBootTest.php
+++ b/tests/Functional/BundleBootTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Traceway\OpenTelemetryBundle\EventSubscriber\ConsoleSubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetrySubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OtelLoggerFlushSubscriber;
+use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredMiddleware as DoctrineMeteredMiddleware;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMetricsMiddleware;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
 use Traceway\OpenTelemetryBundle\Metrics\MeterRegistry;
@@ -194,6 +195,37 @@ final class BundleBootTest extends TestCase
         $this->boot([
             'metrics' => [
                 'messenger' => ['enabled' => true],
+            ],
+        ]);
+    }
+
+    public function testDoctrineMetricsEnabledRegistersMiddleware(): void
+    {
+        $container = $this->boot([
+            'metrics' => [
+                'enabled' => true,
+                'doctrine' => ['enabled' => true],
+            ],
+        ]);
+
+        self::assertTrue($container->has(DoctrineMeteredMiddleware::class));
+    }
+
+    public function testDoctrineMetricsDisabledByDefault(): void
+    {
+        $container = $this->boot(['metrics' => ['enabled' => true]]);
+
+        self::assertFalse($container->has(DoctrineMeteredMiddleware::class));
+    }
+
+    public function testDoctrineMetricsWithoutMetricsEnabledFails(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('metrics.doctrine.enabled');
+
+        $this->boot([
+            'metrics' => [
+                'doctrine' => ['enabled' => true],
             ],
         ]);
     }

--- a/tests/Util/ErrorTypeResolverTest.php
+++ b/tests/Util/ErrorTypeResolverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
+
+final class ErrorTypeResolverTest extends TestCase
+{
+    public function testRootNamespaceExceptionReturnsShortName(): void
+    {
+        self::assertSame('RuntimeException', ErrorTypeResolver::resolve(new \RuntimeException()));
+    }
+
+    public function testNamespacedExceptionReturnsFqcn(): void
+    {
+        $exception = new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('bad');
+
+        self::assertSame(
+            \Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class,
+            ErrorTypeResolver::resolve($exception),
+        );
+    }
+
+    public function testAnonymousExceptionFallsBackToParentClass(): void
+    {
+        $exception = new class('boom') extends \RuntimeException {};
+
+        self::assertSame('RuntimeException', ErrorTypeResolver::resolve($exception));
+    }
+
+    public function testAnonymousExceptionWithThrowableParentFallsBackToThrowable(): void
+    {
+        $exception = new class('boom') extends \Exception {};
+
+        self::assertSame('Exception', ErrorTypeResolver::resolve($exception));
+    }
+}


### PR DESCRIPTION
## Instruments

  - `db.client.operation.duration` (Histogram, `s`) — semconv **Stable**

  Attributes: `db.system.name`, `db.namespace`, `server.address`, `server.port`,
  `db.operation.name` (leading SQL keyword), `db.collection.name` (primary table when
  unambiguous), `error.type` on failure.

  ## Config

  ```yaml
  open_telemetry:
      metrics:
          enabled: true
          doctrine:
              enabled: true
```
  Behaviour

  - Stacks as a regular DBAL middleware. MeteredDriver resolves the per-connection context
  (db.system.name from the driver string, db.namespace from dbname, server address/port from
  connection params) once at connect time and binds it to a single DbMetricRecorder shared by
  the connection wrapper and its prepared statements.
  - Records duration for Connection::query(), Connection::exec(), prepared
  Statement::execute(), and the transaction control methods
  (beginTransaction/commit/rollBack).
  - SQL text is never recorded. Only the leading keyword and the table name when extractable,
  both reused from the existing SqlOperationExtractor to keep cardinality bounded.

  Notes

  - Review patterns from #27 applied up-front: error.type uses FQCN with parent-class
  fallback, histogram declares second-based buckets, every recording path is wrapped in a
  swallowing try/catch so a broken meter provider cannot mask the original DBAL exception.
  - DBAL 3 statement signature differs (execute($params = null) returning bool); the
  MeteredConnectionDbal3/MeteredStatementDbal3 pair mirrors the existing
  TraceableConnectionDbal3/TraceableStatementDbal3 split and is excluded from PHPStan analysis
   the same way (validated via the DBAL 3 CI matrix instead).
  - Same Util\ErrorTypeResolver as the parallel http-client and http-server PRs; whichever
  merges first lands it on master, the others rebase clean.
  - 22 new tests covering recorder, connection, statement, driver, attributes, transaction
  aggregation, anonymous-class fallback, bucket boundaries, broken-recorder swallow.
