### PR TITLE
refactor(metrics): extract error.type resolver to a shared utility

### DIFF
--- a/src/Messenger/OpenTelemetryMetricsMiddleware.php
+++ b/src/Messenger/OpenTelemetryMetricsMiddleware.php
@@ -14,6 +14,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Contracts\Service\ResetInterface;
+use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
 /**
  * Emits OpenTelemetry metrics for Symfony Messenger consumer-side processing.
@@ -105,24 +106,13 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
             $attributes['messaging.destination.name'] = $destination;
         }
         if (null !== $exception) {
-            $attributes['error.type'] = self::resolveErrorType($exception);
+            $attributes['error.type'] = ErrorTypeResolver::resolve($exception);
         }
 
         $this->getMessagesCounter()->add(1, $attributes);
 
         $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
         $this->getDurationHistogram()->record($durationSeconds, $attributes);
-    }
-
-    private static function resolveErrorType(\Throwable $exception): string
-    {
-        $type = $exception::class;
-
-        if (str_contains($type, '@anonymous')) {
-            $type = get_parent_class($exception) ?: \Throwable::class;
-        }
-
-        return $type;
     }
 
     /**

--- a/src/Util/ErrorTypeResolver.php
+++ b/src/Util/ErrorTypeResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Util;
+
+final class ErrorTypeResolver
+{
+    public static function resolve(\Throwable $exception): string
+    {
+        $type = $exception::class;
+
+        if (str_contains($type, '@anonymous')) {
+            $type = get_parent_class($exception) ?: \Throwable::class;
+        }
+
+        return $type;
+    }
+}

--- a/tests/Util/ErrorTypeResolverTest.php
+++ b/tests/Util/ErrorTypeResolverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
+
+final class ErrorTypeResolverTest extends TestCase
+{
+    public function testRootNamespaceExceptionReturnsShortName(): void
+    {
+        self::assertSame('RuntimeException', ErrorTypeResolver::resolve(new \RuntimeException()));
+    }
+
+    public function testNamespacedExceptionReturnsFqcn(): void
+    {
+        $exception = new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('bad');
+
+        self::assertSame(
+            \Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class,
+            ErrorTypeResolver::resolve($exception),
+        );
+    }
+
+    public function testAnonymousExceptionFallsBackToParentClass(): void
+    {
+        $exception = new class('boom') extends \RuntimeException {};
+
+        self::assertSame('RuntimeException', ErrorTypeResolver::resolve($exception));
+    }
+
+    public function testAnonymousExceptionWithThrowableParentFallsBackToThrowable(): void
+    {
+        $exception = new class('boom') extends \Exception {};
+
+        self::assertSame('Exception', ErrorTypeResolver::resolve($exception));
+    }
+}


### PR DESCRIPTION
Pure cleanup. Removes the inline `resolveErrorType()` helper that #27 introduced in         
  `OpenTelemetryMetricsMiddleware` and replaces it with a shared                              
  `Util\ErrorTypeResolver::resolve()`.                                                        
                                                                                              
  ## Why                                                                                      
                                                                                              
  The same FQCN-with-anonymous-class fallback shows up identically in the parallel metrics    
  PRs:                                                                                        
                                                                                              
  - #28 `feat(metrics): add Messenger dispatch metrics`                                      
  - #29 `feat(metrics): add HTTP client metrics`
  - #30 `feat(metrics): add HTTP server metrics`                                             
  - #31 `feat(metrics): add Doctrine DBAL metrics`
                                                                                              
  This PR is mostly useful **once at least one of those lands**: it consolidates the          
  duplication into one place so the next contributor doesn't have to choose which copy to     
  call. If none of the metrics-* PRs are accepted, this refactor is harmless but loses most of
   its motivation.

  ## Behaviour

  No semantic change. The resolver is byte-equivalent to the inline implementation: returns 
  `$exception::class`, falls back to `get_parent_class($exception) ?: \Throwable::class` when 
  the FQCN contains `@anonymous`.
                                                                                              
  ## Tests        

  - `Util\ErrorTypeResolverTest` covers root-namespace, namespaced, 
  anonymous-extends-RuntimeException and anonymous-extends-Exception cases.                   
  - The existing messenger middleware tests continue to assert the same `error.type` values, 
  untouched.                                                                                  
                  
  ## Conflict handling                                                                        
                  
  Whichever metrics-* PR merges first lands `Util\ErrorTypeResolver` on master. After that,
  this PR rebases and the file-introduction commit drops automatically (Git detects identical 
  content). If this PR merges first instead, the metrics-* PRs do the same on rebase.