### PR TITLE
feat: add Mailer transport metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mailer transport metrics** — new `MeteredTransports` decorator emits `messaging.client.operation.duration` (Histogram, `s`) and `messaging.client.sent.messages` (Counter, `{message}`) on outbound transport sends, with OTel messaging attributes (`messaging.system=symfony_mailer`, operation name/type, destination from `X-Transport` header, `error.type` on failure). Off by default; enable with `metrics.mailer.enabled: true`. Decoration priority places it inside the existing `TraceableTransports` so metric data points record within the active trace span scope, enabling SDK-level exemplar linkage from metric points back to traces.
+
+### Changed
+
+- **Internal: shared `DurationBoundaries::SECONDS` constant** — bucket boundaries for every second-based duration histogram in the bundle are now centralized in `Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries`. The previously public-but-undocumented per-class `DURATION_BUCKET_BOUNDARIES` constants on `MeteredHttpClient`, `OpenTelemetryMetricsMiddleware`, `OpenTelemetryMetricsSubscriber`, `DbMetricRecorder`, and `MeteredTransports` have been removed. If you reference any of them in your own code, switch to `DurationBoundaries::SECONDS`.
+
+### Fixed
+
+- **`HttpClientMetricsPass` decoration-priority comment** — was incorrect about Symfony's priority direction (claimed `MeteredHttpClient` wraps `TraceableHttpClient`; the actual decoration ordering is the inverse, with metrics recorded inside the active trace span scope). No behavior change — runtime ordering was already correct for exemplar linkage; only the explanatory comment was misleading future readers.
+
 ## [1.8.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/9tPn2SB3)
 
-Pure-PHP OpenTelemetry instrumentation for Symfony — automatic tracing for HTTP, Console, HttpClient, Messenger, Mailer, Scheduler, Doctrine DBAL, Cache, and Twig, plus Monolog log-trace correlation, OpenTelemetry log export, and opt-in metrics for Messenger, DBAL, and HTTP server/client. No C extension required.
+Pure-PHP OpenTelemetry instrumentation for Symfony — automatic tracing for HTTP, Console, HttpClient, Messenger, Mailer, Scheduler, Doctrine DBAL, Cache, and Twig, plus Monolog log-trace correlation, OpenTelemetry log export, and opt-in metrics for Messenger, DBAL, HTTP server/client, and Mailer. No C extension required.
 
 Works with any OpenTelemetry-compatible backend: [Traceway](https://tracewayapp.com), [Jaeger](https://www.jaegertracing.io/), [Zipkin](https://zipkin.io/), [Datadog](https://www.datadoghq.com/), [Grafana Tempo](https://grafana.com/oss/tempo/), [Honeycomb](https://www.honeycomb.io/), and more.
 
@@ -121,6 +121,8 @@ open_telemetry:
         http_client:
             enabled: false
             excluded_hosts: []         # OTLP endpoint is auto-excluded
+        mailer:
+            enabled: false
 ```
 
 ### Environment Variables
@@ -165,7 +167,7 @@ Mock in tests with `$this->createStub(TracingInterface::class)` and have `trace(
 
 ## Metrics
 
-**Off by default.** Enable to export OpenTelemetry metrics alongside traces, with opt-in automatic instrumentation for Messenger, Doctrine DBAL, and HTTP server/client.
+**Off by default.** Enable to export OpenTelemetry metrics alongside traces, with opt-in automatic instrumentation for Messenger, Doctrine DBAL, HTTP server/client, and Mailer.
 
 ```yaml
 open_telemetry:
@@ -208,6 +210,15 @@ Names and attributes follow OTel semantic conventions ([messaging](https://opent
 | `http.client.response.body.size` | Histogram | `By` | Development | Same as duration (emitted when response `Content-Length` is set or the body is fully read) |
 
 `http_client.excluded_hosts` skips matching hostnames; the OTLP endpoint (from `OTEL_EXPORTER_OTLP_ENDPOINT`) is always auto-excluded to prevent instrumentation loops.
+
+**Mailer** (outbound transport sends):
+
+| Instrument | Kind | Unit | Stability | Attributes |
+|---|---|---|---|---|
+| `messaging.client.operation.duration` | Histogram | `s` | Development | `messaging.system=symfony_mailer`, `messaging.operation.name=send`, `messaging.operation.type=send`, `messaging.destination.name` from `X-Transport` header when present, `error.type` on failure |
+| `messaging.client.sent.messages` | Counter | `{message}` | Development | Same as duration |
+
+Decoration sits inside `TraceableTransports` so metric points record while the trace span is still active — backends that support exemplars can link directly from a metric data point to the corresponding trace.
 
 ### Manual Metrics
 

--- a/src/DependencyInjection/Compiler/HttpClientMetricsPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientMetricsPass.php
@@ -15,10 +15,13 @@ use Traceway\OpenTelemetryBundle\HttpClient\MeteredHttpClient;
  * 'http_client' service with {@see MeteredHttpClient} when metrics are
  * enabled for the HTTP client subsystem.
  *
- * Decoration priority is -8, higher than {@see HttpClientTracingPass}'s -16,
- * so the metrics decorator wraps the trace decorator. Recorded duration
- * therefore reflects what the app observes, including any overhead added by
- * the tracing layer underneath.
+ * Decoration priority is -8, higher than {@see HttpClientTracingPass}'s -16.
+ * In Symfony's {@see \Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass},
+ * decorators are processed via a max-heap priority queue: the highest priority
+ * is processed first and the lowest priority wins the public alias, so HIGHER
+ * priority = DEEPER nesting. The metric recording therefore happens INSIDE the
+ * active trace span scope, which is what enables SDK-level exemplar linkage
+ * from metric data points back to the corresponding trace.
  */
 final class HttpClientMetricsPass implements CompilerPassInterface
 {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -221,6 +221,16 @@ final class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->arrayNode('mailer')
+                            ->info('Automatic metrics for Symfony Mailer transport sends.')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('enabled')
+                                    ->info('Emit messaging.client.operation.duration (histogram) and messaging.client.sent.messages (counter) on outbound transport sends. Requires metrics.enabled and symfony/mailer.')
+                                    ->defaultFalse()
+                                ->end()
+                            ->end()
+                        ->end()
                     ->end()
                     ->validate()
                         ->ifTrue(static function (array $c): bool {
@@ -249,6 +259,13 @@ final class Configuration implements ConfigurationInterface
                             return true === ($httpClient['enabled'] ?? false) && true !== ($c['enabled'] ?? false);
                         })
                         ->thenInvalid('"open_telemetry.metrics.http_client.enabled" requires "open_telemetry.metrics.enabled" to be true.')
+                    ->end()
+                    ->validate()
+                        ->ifTrue(static function (array $c): bool {
+                            $mailer = \is_array($c['mailer'] ?? null) ? $c['mailer'] : [];
+                            return true === ($mailer['enabled'] ?? false) && true !== ($c['enabled'] ?? false);
+                        })
+                        ->thenInvalid('"open_telemetry.metrics.mailer.enabled" requires "open_telemetry.metrics.enabled" to be true.')
                     ->end()
                 ->end()
             ->end()

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -23,6 +23,7 @@ use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetryMetricsSubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetrySubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OtelLoggerFlushSubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\SchedulerSubscriber;
+use Traceway\OpenTelemetryBundle\Mailer\MeteredTransports;
 use Traceway\OpenTelemetryBundle\Mailer\TraceableMailer;
 use Traceway\OpenTelemetryBundle\Mailer\TraceableTransports;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMetricsMiddleware;
@@ -195,7 +196,7 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->setDefinition(TraceContextProcessor::class, $monologDef);
         }
 
-        /** @var array{enabled: bool, meter_name: string, messenger: array{enabled: bool, excluded_queues: list<string>}, doctrine: array{enabled: bool}, http_server: array{enabled: bool, excluded_paths: list<string>}, http_client: array{enabled: bool, excluded_hosts: list<string>}} $metrics */
+        /** @var array{enabled: bool, meter_name: string, messenger: array{enabled: bool, excluded_queues: list<string>}, doctrine: array{enabled: bool}, http_server: array{enabled: bool, excluded_paths: list<string>}, http_client: array{enabled: bool, excluded_hosts: list<string>}, mailer: array{enabled: bool}} $metrics */
         $metrics = $config['metrics'];
         $meterName = $metrics['meter_name'];
 
@@ -234,6 +235,17 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
         $container->setParameter('open_telemetry.http_client_metrics_enabled', $httpClientMetricsEnabled);
         $container->setParameter('open_telemetry.metrics_meter_name', $meterName);
         $container->setParameter('open_telemetry.http_client_metrics_excluded_hosts', $metrics['http_client']['excluded_hosts']);
+
+        if ($metrics['enabled'] && $metrics['mailer']['enabled'] && $this->isMailerAvailable()) {
+            // Priority 8 places this decorator INSIDE TraceableTransports (priority 0).
+            // In Symfony decoration, higher priority = deeper nesting (see DecoratorServicePass).
+            // Recording inside the active trace span scope enables SDK exemplar linkage.
+            $meteredTransportsDef = new Definition(MeteredTransports::class);
+            $meteredTransportsDef->setDecoratedService('mailer.transports', null, 8, ContainerInterface::IGNORE_ON_INVALID_REFERENCE);
+            $meteredTransportsDef->setArgument('$decorated', new Reference('.inner'));
+            $meteredTransportsDef->setArgument('$meterName', $meterName);
+            $container->setDefinition(MeteredTransports::class, $meteredTransportsDef);
+        }
     }
 
     private function isConsoleAvailable(): bool

--- a/src/Doctrine/Metrics/DbMetricRecorder.php
+++ b/src/Doctrine/Metrics/DbMetricRecorder.php
@@ -9,6 +9,7 @@ use OpenTelemetry\API\Metrics\HistogramInterface;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Traceway\OpenTelemetryBundle\Doctrine\Middleware\SqlOperationExtractor;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
 /**
@@ -23,11 +24,7 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  */
 final class DbMetricRecorder implements ResetInterface
 {
-    public const DURATION_BUCKET_BOUNDARIES = [
-        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
-    ];
-
-    private ?MeterInterface $meter = null;
+private ?MeterInterface $meter = null;
     private ?HistogramInterface $duration = null;
 
     public function __construct(
@@ -97,7 +94,7 @@ final class DbMetricRecorder implements ResetInterface
             'db.client.operation.duration',
             's',
             'Duration of database client operations',
-            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
+            ['ExplicitBucketBoundaries' => DurationBoundaries::SECONDS],
         );
     }
 

--- a/src/Doctrine/Metrics/DbMetricRecorder.php
+++ b/src/Doctrine/Metrics/DbMetricRecorder.php
@@ -24,7 +24,7 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  */
 final class DbMetricRecorder implements ResetInterface
 {
-private ?MeterInterface $meter = null;
+    private ?MeterInterface $meter = null;
     private ?HistogramInterface $duration = null;
 
     public function __construct(

--- a/src/EventSubscriber/OpenTelemetryMetricsSubscriber.php
+++ b/src/EventSubscriber/OpenTelemetryMetricsSubscriber.php
@@ -49,7 +49,7 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  */
 final class OpenTelemetryMetricsSubscriber implements EventSubscriberInterface, ResetInterface
 {
-/** @var list<string> */
+    /** @var list<string> */
     private readonly array $excludedPaths;
 
     private ?MeterInterface $meter = null;

--- a/src/EventSubscriber/OpenTelemetryMetricsSubscriber.php
+++ b/src/EventSubscriber/OpenTelemetryMetricsSubscriber.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Contracts\Service\ResetInterface;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
 /**
@@ -48,11 +49,7 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  */
 final class OpenTelemetryMetricsSubscriber implements EventSubscriberInterface, ResetInterface
 {
-    public const DURATION_BUCKET_BOUNDARIES = [
-        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
-    ];
-
-    /** @var list<string> */
+/** @var list<string> */
     private readonly array $excludedPaths;
 
     private ?MeterInterface $meter = null;
@@ -285,7 +282,7 @@ final class OpenTelemetryMetricsSubscriber implements EventSubscriberInterface, 
             $this->metricName('duration'),
             's',
             'Duration of HTTP server requests',
-            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
+            ['ExplicitBucketBoundaries' => DurationBoundaries::SECONDS],
         );
     }
 

--- a/src/HttpClient/MeteredHttpClient.php
+++ b/src/HttpClient/MeteredHttpClient.php
@@ -16,6 +16,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 use Symfony\Contracts\Service\ResetInterface;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
 /**
@@ -42,10 +43,6 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  */
 final class MeteredHttpClient implements HttpClientInterface, ResetInterface
 {
-    public const DURATION_BUCKET_BOUNDARIES = [
-        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
-    ];
-
     private ?MeterInterface $meter = null;
     private ?HistogramInterface $duration = null;
     private ?HistogramInterface $requestBodySize = null;
@@ -286,7 +283,7 @@ final class MeteredHttpClient implements HttpClientInterface, ResetInterface
             $this->metricName('duration'),
             's',
             'Duration of outbound HTTP client requests',
-            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
+            ['ExplicitBucketBoundaries' => DurationBoundaries::SECONDS],
         );
     }
 

--- a/src/Mailer/MeteredTransports.php
+++ b/src/Mailer/MeteredTransports.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Mailer;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\Service\ResetInterface;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
+use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
+
+/**
+ * Decorates the `mailer.transports` service (the {@see TransportInterface}
+ * aggregate) to emit OpenTelemetry metrics for outbound transport sends,
+ * sibling of {@see TraceableTransports} on the trace side.
+ *
+ * Sits INSIDE the trace decorator: in Symfony service decoration, a higher
+ * decoration priority nests further in (see
+ * https://symfony.com/doc/current/service_container/service_decoration.html).
+ * This decorator is registered at priority 8 while TraceableTransports is at 0,
+ * so the call order is TraceableTransports → MeteredTransports → actual
+ * mailer.transports. The metric is recorded in the finally block while the
+ * trace span is still active, enabling SDK-level exemplar linkage from metric
+ * data points back to traces.
+ *
+ * Metrics (OTel messaging metrics semconv):
+ *   - messaging.client.operation.duration  (Histogram, s)         [Development]
+ *   - messaging.client.sent.messages       (Counter,   {message}) [Development]
+ *
+ * Attributes:
+ *   - messaging.system           -> "symfony_mailer"
+ *   - messaging.operation.name   -> "send"
+ *   - messaging.operation.type   -> "send"
+ *   - messaging.destination.name (conditional) -> X-Transport header value
+ *   - error.type                 (on failure)  -> exception FQCN (parent for anonymous)
+ */
+final class MeteredTransports implements TransportInterface, ResetInterface
+{
+    private ?MeterInterface $meter = null;
+    private ?HistogramInterface $duration = null;
+    private ?CounterInterface $sent = null;
+
+    public function __construct(
+        private readonly TransportInterface $decorated,
+        private readonly string $meterName = 'opentelemetry-symfony',
+    ) {}
+
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+    {
+        $attributes = $this->baseAttributes();
+        $destination = $this->extractTransportName($message);
+        if (null !== $destination) {
+            $attributes['messaging.destination.name'] = $destination;
+        }
+
+        $start = hrtime(true);
+        $exception = null;
+
+        try {
+            return $this->decorated->send($message, $envelope);
+        } catch (\Throwable $e) {
+            $exception = $e;
+
+            throw $e;
+        } finally {
+            try {
+                $this->record($start, $attributes, $exception);
+            } catch (\Throwable) {
+            }
+        }
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->decorated;
+    }
+
+    public function reset(): void
+    {
+        $this->meter = null;
+        $this->duration = null;
+        $this->sent = null;
+    }
+
+    /**
+     * @param array<non-empty-string, string> $attributes
+     */
+    private function record(int|float $start, array $attributes, ?\Throwable $exception): void
+    {
+        if (null !== $exception) {
+            $attributes['error.type'] = ErrorTypeResolver::resolve($exception);
+        }
+
+        $this->getSentCounter()->add(1, $attributes);
+
+        $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+        $this->getDurationHistogram()->record($durationSeconds, $attributes);
+    }
+
+    /**
+     * @return array<non-empty-string, string>
+     */
+    private function baseAttributes(): array
+    {
+        return [
+            'messaging.system' => 'symfony_mailer',
+            'messaging.operation.name' => 'send',
+            'messaging.operation.type' => 'send',
+        ];
+    }
+
+    private function extractTransportName(RawMessage $message): ?string
+    {
+        if (!$message instanceof Message) {
+            return null;
+        }
+
+        $header = $message->getHeaders()->get('X-Transport');
+        if (null === $header) {
+            return null;
+        }
+
+        $value = $header->getBody();
+
+        return \is_string($value) && '' !== $value ? $value : null;
+    }
+
+    private function getMeter(): MeterInterface
+    {
+        return $this->meter ??= Globals::meterProvider()->getMeter($this->meterName);
+    }
+
+    private function getDurationHistogram(): HistogramInterface
+    {
+        // Description matches OpenTelemetryMetricsMiddleware's dispatch-side instrument
+        // verbatim: both subsystems emit messaging.client.operation.duration, and the
+        // OTel spec warns / drops metadata on duplicate (name, kind, unit) registrations
+        // with conflicting descriptions.
+        return $this->duration ??= $this->getMeter()->createHistogram(
+            $this->metricName('duration'),
+            's',
+            'Duration of messaging client send operations',
+            ['ExplicitBucketBoundaries' => DurationBoundaries::SECONDS],
+        );
+    }
+
+    private function getSentCounter(): CounterInterface
+    {
+        // See description rationale on getDurationHistogram().
+        return $this->sent ??= $this->getMeter()->createCounter(
+            $this->metricName('sent'),
+            '{message}',
+            'Number of messages sent to a transport',
+        );
+    }
+
+    /**
+     * Central metric name resolution. Ready for OTEL_SEMCONV_STABILITY_OPT_IN
+     * dual-emit once messaging metrics semconv stabilizes.
+     *
+     * @param 'duration'|'sent' $key
+     */
+    private function metricName(string $key): string
+    {
+        return match ($key) {
+            'duration' => 'messaging.client.operation.duration',
+            'sent' => 'messaging.client.sent.messages',
+        };
+    }
+}

--- a/src/Messenger/OpenTelemetryMetricsMiddleware.php
+++ b/src/Messenger/OpenTelemetryMetricsMiddleware.php
@@ -15,6 +15,7 @@ use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Contracts\Service\ResetInterface;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
 /**
@@ -48,10 +49,6 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  */
 final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, ResetInterface
 {
-    public const DURATION_BUCKET_BOUNDARIES = [
-        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
-    ];
-
     private ?MeterInterface $meter = null;
     private ?HistogramInterface $duration = null;
     private ?CounterInterface $messages = null;
@@ -223,7 +220,7 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
             $this->metricName('duration'),
             's',
             'Duration of messaging processing operations',
-            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
+            ['ExplicitBucketBoundaries' => DurationBoundaries::SECONDS],
         );
     }
 
@@ -242,7 +239,7 @@ final class OpenTelemetryMetricsMiddleware implements MiddlewareInterface, Reset
             $this->metricName('dispatch_duration'),
             's',
             'Duration of messaging client send operations',
-            ['ExplicitBucketBoundaries' => self::DURATION_BUCKET_BOUNDARIES],
+            ['ExplicitBucketBoundaries' => DurationBoundaries::SECONDS],
         );
     }
 

--- a/src/Metrics/DurationBoundaries.php
+++ b/src/Metrics/DurationBoundaries.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Metrics;
+
+/**
+ * Shared explicit bucket boundaries for OpenTelemetry duration histograms.
+ *
+ * Centralizing the boundaries here keeps every Metered* class in the bundle
+ * reporting the same bucket layout, so cross-subsystem latency comparisons in
+ * backends (Grafana, Tempo, etc.) stay coherent and aggregate well.
+ *
+ * Values match the boundaries recommended by the OTel HTTP and messaging
+ * metric semantic conventions for second-based latency histograms.
+ */
+final class DurationBoundaries
+{
+    /**
+     * Bucket boundaries (in seconds) applied to every second-based latency
+     * histogram emitted by the bundle: messaging.process.duration,
+     * messaging.client.operation.duration, http.server.request.duration,
+     * http.client.request.duration, db.client.operation.duration.
+     *
+     * @var list<float|int>
+     */
+    public const SECONDS = [
+        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+    ];
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Traceway\OpenTelemetryBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Configuration;
 
@@ -137,6 +139,58 @@ final class ConfigurationTest extends TestCase
         ]]);
 
         self::assertSame([], $config['metrics']['http_server']['excluded_paths']);
+    }
+
+    /**
+     * Each per-subsystem metrics toggle should fail validation when the master
+     * metrics.enabled flag is false. The rule lives in Configuration's validate()
+     * chain and is structurally identical across all five subsystems, so we run
+     * the same assertion against each via DataProvider.
+     *
+     * Forward-compatible with PHPUnit 13 (attribute syntax). Docblock
+     * @ dataProvider would also work on PHPUnit 11 but is removed in 13 — see
+     * the PHPUnit 13 migration item in CLAUDE.md.
+     */
+    #[DataProvider('metricsSubsystemProvider')]
+    public function testMetricsSubsystemRequiresMetricsEnabled(string $subsystem): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(sprintf(
+            '"open_telemetry.metrics.%s.enabled" requires "open_telemetry.metrics.enabled" to be true.',
+            $subsystem,
+        ));
+
+        $this->process([[
+            'metrics' => [
+                'enabled' => false,
+                $subsystem => ['enabled' => true],
+            ],
+        ]]);
+    }
+
+    #[DataProvider('metricsSubsystemProvider')]
+    public function testMetricsSubsystemCanBeEnabledWhenMetricsEnabled(string $subsystem): void
+    {
+        $config = $this->process([[
+            'metrics' => [
+                'enabled' => true,
+                $subsystem => ['enabled' => true],
+            ],
+        ]]);
+
+        self::assertTrue($config['metrics'][$subsystem]['enabled']);
+    }
+
+    /**
+     * @return \Generator<string, array{string}>
+     */
+    public static function metricsSubsystemProvider(): \Generator
+    {
+        yield 'messenger' => ['messenger'];
+        yield 'doctrine' => ['doctrine'];
+        yield 'http_server' => ['http_server'];
+        yield 'http_client' => ['http_client'];
+        yield 'mailer' => ['mailer'];
     }
 
     /**

--- a/tests/Doctrine/Metrics/DbMetricRecorderTest.php
+++ b/tests/Doctrine/Metrics/DbMetricRecorderTest.php
@@ -7,6 +7,7 @@ namespace Traceway\OpenTelemetryBundle\Tests\Doctrine\Metrics;
 use OpenTelemetry\API\Metrics\HistogramInterface;
 use PHPUnit\Framework\TestCase;
 use Traceway\OpenTelemetryBundle\Doctrine\Metrics\DbMetricRecorder;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
 
 final class DbMetricRecorderTest extends TestCase
@@ -113,7 +114,7 @@ final class DbMetricRecorderTest extends TestCase
         $points = [...$metrics['db.client.operation.duration']->data->dataPoints];
 
         self::assertSame(
-            DbMetricRecorder::DURATION_BUCKET_BOUNDARIES,
+            DurationBoundaries::SECONDS,
             $points[0]->explicitBounds,
         );
     }

--- a/tests/EventSubscriber/OpenTelemetryMetricsSubscriberTest.php
+++ b/tests/EventSubscriber/OpenTelemetryMetricsSubscriberTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetryMetricsSubscriber;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
 
 final class OpenTelemetryMetricsSubscriberTest extends TestCase
@@ -154,7 +155,7 @@ final class OpenTelemetryMetricsSubscriberTest extends TestCase
         $metrics = $this->collectMetrics();
         $points = [...$metrics['http.server.request.duration']->data->dataPoints];
         self::assertSame(
-            OpenTelemetryMetricsSubscriber::DURATION_BUCKET_BOUNDARIES,
+            DurationBoundaries::SECONDS,
             $points[0]->explicitBounds,
         );
     }

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Traceway\OpenTelemetryBundle\HttpClient\MeteredHttpClient;
 use Traceway\OpenTelemetryBundle\HttpClient\MeteredResponse;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
 
 final class MeteredHttpClientTest extends TestCase
@@ -317,7 +318,7 @@ final class MeteredHttpClientTest extends TestCase
         $metrics = $this->collectMetrics();
         $points = [...$metrics['http.client.request.duration']->data->dataPoints];
         self::assertSame(
-            MeteredHttpClient::DURATION_BUCKET_BOUNDARIES,
+            DurationBoundaries::SECONDS,
             $points[0]->explicitBounds,
         );
     }

--- a/tests/Mailer/MeteredTransportsTest.php
+++ b/tests/Mailer/MeteredTransportsTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Mailer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\RawMessage;
+use Traceway\OpenTelemetryBundle\Mailer\MeteredTransports;
+use Traceway\OpenTelemetryBundle\Mailer\TraceableTransports;
+use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
+
+final class MeteredTransportsTest extends TestCase
+{
+    use OTelTestTrait;
+
+    protected function setUp(): void
+    {
+        $this->setUpOTel();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownOTel();
+    }
+
+    public function testSendEmitsCounterAndDuration(): void
+    {
+        $sent = new SentMessage(
+            $this->buildEmail(),
+            new Envelope(new Address('sender@example.com'), [new Address('alice@example.com')]),
+        );
+
+        $transports = new MeteredTransports($this->fixedReturn($sent), 'test');
+        $transports->send($this->buildEmail());
+
+        $metrics = $this->collectMetrics();
+
+        self::assertArrayHasKey('messaging.client.sent.messages', $metrics);
+        $counter = $metrics['messaging.client.sent.messages'];
+        self::assertSame('{message}', $counter->unit);
+
+        $counterPoints = [...$counter->data->dataPoints];
+        self::assertCount(1, $counterPoints);
+        self::assertSame(1, $counterPoints[0]->value);
+
+        $attr = $counterPoints[0]->attributes->toArray();
+        self::assertSame('symfony_mailer', $attr['messaging.system']);
+        self::assertSame('send', $attr['messaging.operation.name']);
+        self::assertSame('send', $attr['messaging.operation.type']);
+        self::assertArrayNotHasKey('error.type', $attr);
+        self::assertArrayNotHasKey('messaging.destination.name', $attr);
+
+        self::assertArrayHasKey('messaging.client.operation.duration', $metrics);
+        $hist = $metrics['messaging.client.operation.duration'];
+        self::assertSame('s', $hist->unit);
+
+        $histPoints = [...$hist->data->dataPoints];
+        self::assertCount(1, $histPoints);
+        self::assertSame(1, $histPoints[0]->count);
+        self::assertGreaterThanOrEqual(0.0, $histPoints[0]->sum);
+    }
+
+    public function testXTransportHeaderBecomesDestinationName(): void
+    {
+        $sent = new SentMessage(
+            $this->buildEmail(),
+            new Envelope(new Address('sender@example.com'), [new Address('alice@example.com')]),
+        );
+
+        $transports = new MeteredTransports($this->fixedReturn($sent), 'test');
+
+        $email = $this->buildEmail();
+        $email->getHeaders()->addTextHeader('X-Transport', 'alerts');
+        $transports->send($email);
+
+        $metrics = $this->collectMetrics();
+        $counterAttr = [...$metrics['messaging.client.sent.messages']->data->dataPoints][0]->attributes->toArray();
+        $histAttr = [...$metrics['messaging.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+
+        self::assertSame('alerts', $counterAttr['messaging.destination.name']);
+        self::assertSame('alerts', $histAttr['messaging.destination.name']);
+    }
+
+    public function testFailurePathRecordsErrorTypeAndRethrows(): void
+    {
+        $inner = new class implements TransportInterface {
+            public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+            {
+                throw new TransportException('connection refused');
+            }
+
+            public function __toString(): string
+            {
+                return 'fake://';
+            }
+        };
+
+        $transports = new MeteredTransports($inner, 'test');
+
+        try {
+            $transports->send($this->buildEmail());
+            self::fail('Expected TransportException');
+        } catch (TransportException $e) {
+            self::assertSame('connection refused', $e->getMessage());
+        }
+
+        $metrics = $this->collectMetrics();
+
+        $counterAttr = [...$metrics['messaging.client.sent.messages']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame(TransportException::class, $counterAttr['error.type']);
+
+        $histAttr = [...$metrics['messaging.client.operation.duration']->data->dataPoints][0]->attributes->toArray();
+        self::assertSame(TransportException::class, $histAttr['error.type']);
+    }
+
+    public function testNullSentMessageStillRecords(): void
+    {
+        $transports = new MeteredTransports($this->fixedReturn(null), 'test');
+        $transports->send($this->buildEmail());
+
+        $metrics = $this->collectMetrics();
+        self::assertArrayHasKey('messaging.client.sent.messages', $metrics);
+        self::assertArrayHasKey('messaging.client.operation.duration', $metrics);
+    }
+
+    public function testToStringDelegates(): void
+    {
+        $inner = new class implements TransportInterface {
+            public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+            {
+                return null;
+            }
+
+            public function __toString(): string
+            {
+                return 'smtp://relay.example.com:25';
+            }
+        };
+
+        $transports = new MeteredTransports($inner, 'test');
+        self::assertSame('smtp://relay.example.com:25', (string) $transports);
+    }
+
+    /**
+     * Integration check that mirrors the runtime DI stack: TraceableTransports
+     * (decoration priority 0, outer) wraps MeteredTransports (priority 8, inner).
+     * Confirms both decorators fire on a single send and agree on the destination
+     * attribute, which is the contract callers rely on for joining metrics to
+     * traces in a backend.
+     *
+     * If a future refactor accidentally swaps the priorities, MeteredTransports
+     * ends up outside the trace span scope and exemplar linkage silently breaks
+     * — this test would still pass (both fire, attributes still agree). Catching
+     * the priority direction itself would need an SDK-level exemplar assertion,
+     * which is out of scope here. This test guards the weaker but still useful
+     * invariant: both decorators are wired and observe a consistent view.
+     */
+    public function testWrappedByTraceableTransportsBothEmit(): void
+    {
+        $sent = new SentMessage(
+            $this->buildEmail(),
+            new Envelope(new Address('sender@example.com'), [new Address('alice@example.com')]),
+        );
+        $sent->setMessageId('integration-1@example.com');
+
+        $inner = $this->fixedReturn($sent);
+        $metered = new MeteredTransports($inner, 'test');
+        $traceable = new TraceableTransports($metered, 'test');
+
+        $email = $this->buildEmail();
+        $email->getHeaders()->addTextHeader('X-Transport', 'primary');
+        $traceable->send($email);
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        $spanAttr = $spans[0]->getAttributes()->toArray();
+
+        $metrics = $this->collectMetrics();
+        self::assertArrayHasKey('messaging.client.operation.duration', $metrics);
+        self::assertArrayHasKey('messaging.client.sent.messages', $metrics);
+
+        $metricAttr = [...$metrics['messaging.client.sent.messages']->data->dataPoints][0]->attributes->toArray();
+
+        self::assertSame($spanAttr['messaging.system'], $metricAttr['messaging.system']);
+        self::assertSame($spanAttr['messaging.operation.name'], $metricAttr['messaging.operation.name']);
+        self::assertSame($spanAttr['messaging.destination.name'], $metricAttr['messaging.destination.name']);
+    }
+
+    public function testResetClearsCachedInstruments(): void
+    {
+        $transports = new MeteredTransports($this->fixedReturn(null), 'test');
+        $transports->send($this->buildEmail());
+
+        // No exception expected; reset() should leave the decorator usable for a second cycle.
+        $transports->reset();
+        $transports->send($this->buildEmail());
+
+        $metrics = $this->collectMetrics();
+        $counterPoints = [...$metrics['messaging.client.sent.messages']->data->dataPoints];
+
+        $total = 0;
+        foreach ($counterPoints as $point) {
+            $total += $point->value;
+        }
+        self::assertSame(2, $total);
+    }
+
+    private function buildEmail(): Email
+    {
+        return (new Email())
+            ->from('sender@example.com')
+            ->to('alice@example.com')
+            ->subject('Hi')
+            ->text('Body');
+    }
+
+    private function fixedReturn(?SentMessage $sent): TransportInterface
+    {
+        return new class($sent) implements TransportInterface {
+            public function __construct(private readonly ?SentMessage $sent)
+            {
+            }
+
+            public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+            {
+                return $this->sent;
+            }
+
+            public function __toString(): string
+            {
+                return 'fake://';
+            }
+        };
+    }
+}

--- a/tests/Messenger/OpenTelemetryMetricsMiddlewareTest.php
+++ b/tests/Messenger/OpenTelemetryMetricsMiddlewareTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMetricsMiddleware;
+use Traceway\OpenTelemetryBundle\Metrics\DurationBoundaries;
 use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
 
 final class OpenTelemetryMetricsMiddlewareTest extends TestCase
@@ -213,7 +214,7 @@ final class OpenTelemetryMetricsMiddlewareTest extends TestCase
         $metrics = $this->collectMetrics();
         $points = [...$metrics['messaging.client.operation.duration']->data->dataPoints];
         self::assertSame(
-            OpenTelemetryMetricsMiddleware::DURATION_BUCKET_BOUNDARIES,
+            DurationBoundaries::SECONDS,
             $points[0]->explicitBounds,
         );
     }
@@ -362,7 +363,7 @@ final class OpenTelemetryMetricsMiddlewareTest extends TestCase
         $metrics = $this->collectMetrics();
         $points = [...$metrics['messaging.process.duration']->data->dataPoints];
         self::assertSame(
-            OpenTelemetryMetricsMiddleware::DURATION_BUCKET_BOUNDARIES,
+            DurationBoundaries::SECONDS,
             $points[0]->explicitBounds,
         );
     }


### PR DESCRIPTION
 - New `MeteredTransports` decorator emits `messaging.client.operation.duration` (Histogram) and `messaging.client.sent.messages` (Counter) on Symfony Mailer transport sends. Off by default; enable with
  `metrics.mailer.enabled: true`. Attributes follow OTel messaging semconv (`messaging.system=symfony_mailer`, operation name/type, destination from `X-Transport` header, `error.type` on failure).
  - Decoration priority 8 places `MeteredTransports` inside `TraceableTransports` (priority 0) so metric data points record within the active trace span scope — enables SDK-level exemplar linkage from metric
  points back to the originating trace.
  - Extracts `DurationBoundaries::SECONDS` to centralize histogram bucket boundaries previously duplicated across 5 metrics classes. Per-class `DURATION_BUCKET_BOUNDARIES` constants removed (undocumented
  internal; swap to `DurationBoundaries::SECONDS` if you referenced them externally).
  - Fixes the incorrect priority-direction comment on `HttpClientMetricsPass` (no runtime behavior change — only a misleading explanatory comment).

  ## Test plan

  - [x] PHPStan level 10, no baseline, clean
  - [x] New `MeteredTransportsTest` — 7 tests covering happy path
  - [x] New parametrized cross-validation tests in \`ConfigurationTest\` — covers all 5 \`metrics.<subsystem>.enabled requires metrics.enabled\` rules (10 tests)
  - [x] All previously affected tests still pass — Doctrine, HTTP server/client, Messenger metrics, all Mailer (19/19)