### PR TITLE
Update `SplObjectStorage` methods used to resolve deprecations

### DIFF
--- a/src/EventSubscriber/ConsoleSubscriber.php
+++ b/src/EventSubscriber/ConsoleSubscriber.php
@@ -127,7 +127,7 @@ final class ConsoleSubscriber implements EventSubscriberInterface, ResetInterfac
 
         $updated = [$span, $scope, true];
         $command = $event->getCommand();
-        if (null !== $command && $this->commandSpans->contains($command)) {
+        if (null !== $command && $this->commandSpans->offsetExists($command)) {
             $this->commandSpans[$command] = $updated;
         } else {
             $this->orphanSpan = $updated;
@@ -154,8 +154,8 @@ final class ConsoleSubscriber implements EventSubscriberInterface, ResetInterfac
         $span->end();
         $scope->detach();
 
-        if (null !== $command && $this->commandSpans->contains($command)) {
-            $this->commandSpans->detach($command);
+        if (null !== $command && $this->commandSpans->offsetExists($command)) {
+            $this->commandSpans->offsetUnset($command);
         } else {
             $this->orphanSpan = null;
         }
@@ -166,7 +166,7 @@ final class ConsoleSubscriber implements EventSubscriberInterface, ResetInterfac
      */
     private function resolveEntry(?Command $command): ?array
     {
-        if (null !== $command && $this->commandSpans->contains($command)) {
+        if (null !== $command && $this->commandSpans->offsetExists($command)) {
             return $this->commandSpans[$command];
         }
 

--- a/src/EventSubscriber/SchedulerSubscriber.php
+++ b/src/EventSubscriber/SchedulerSubscriber.php
@@ -110,12 +110,12 @@ final class SchedulerSubscriber implements EventSubscriberInterface, ResetInterf
         }
 
         $message = $event->getMessage();
-        if (!$this->spans->contains($message)) {
+        if (!$this->spans->offsetExists($message)) {
             return;
         }
 
         [$span, $scope] = $this->spans[$message];
-        $this->spans->detach($message);
+        $this->spans->offsetUnset($message);
 
         $span->setAttribute('scheduler.cancelled', true);
         $span->setStatus(StatusCode::STATUS_OK);
@@ -126,12 +126,12 @@ final class SchedulerSubscriber implements EventSubscriberInterface, ResetInterf
     public function onPostRun(PostRunEvent $event): void
     {
         $message = $event->getMessage();
-        if (!$this->spans->contains($message)) {
+        if (!$this->spans->offsetExists($message)) {
             return;
         }
 
         [$span, $scope] = $this->spans[$message];
-        $this->spans->detach($message);
+        $this->spans->offsetUnset($message);
 
         $span->setStatus(StatusCode::STATUS_OK);
         $scope->detach();
@@ -141,12 +141,12 @@ final class SchedulerSubscriber implements EventSubscriberInterface, ResetInterf
     public function onFailure(FailureEvent $event): void
     {
         $message = $event->getMessage();
-        if (!$this->spans->contains($message)) {
+        if (!$this->spans->offsetExists($message)) {
             return;
         }
 
         [$span, $scope] = $this->spans[$message];
-        $this->spans->detach($message);
+        $this->spans->offsetUnset($message);
 
         $error = $event->getError();
         $span->recordException($error);

--- a/src/Twig/OpenTelemetryTwigExtension.php
+++ b/src/Twig/OpenTelemetryTwigExtension.php
@@ -101,12 +101,12 @@ final class OpenTelemetryTwigExtension extends AbstractExtension implements Rese
 
     public function leave(Profile $profile): void
     {
-        if (!$this->spans->contains($profile)) {
+        if (!$this->spans->offsetExists($profile)) {
             return;
         }
 
         [$span, $scope] = $this->spans[$profile];
-        $this->spans->detach($profile);
+        $this->spans->offsetUnset($profile);
 
         $span->end();
         $scope->detach();


### PR DESCRIPTION
Methods [detach](https://www.php.net/manual/en/splobjectstorage.detach.php) and [contains](https://www.php.net/manual/en/splobjectstorage.contains.php) from `SplObjectStorage`  are deprecated since php 8.5

This PR replaces their usage by new methods to resolve deprecations