### PR TITLE
ci: add PHP 8.5 job with --fail-on-deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,16 @@ jobs:
             dbal: '^4.0'
             phpunit: '^13.0'
             coverage: false
+          # Catch native PHP deprecations (e.g. SplObjectStorage::contains/detach
+          # deprecated in 8.5) before users hit them. --fail-on-deprecation makes
+          # PHPUnit exit non-zero on any E_USER_DEPRECATED; the symfony/phpunit-bridge
+          # bootstrap converts native E_DEPRECATED into the same channel.
+          - php: '8.5'
+            symfony: '8.0.*'
+            dbal: '^4.0'
+            phpunit: '^13.0'
+            coverage: false
+            fail_on_deprecation: true
     steps:
       - uses: actions/checkout@v4
 
@@ -102,11 +112,11 @@ jobs:
 
       - name: Run PHPUnit
         if: ${{ !matrix.coverage }}
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit ${{ matrix.fail_on_deprecation && '--fail-on-deprecation --fail-on-notice' || '' }}
 
       - name: Run PHPUnit with coverage
         if: ${{ matrix.coverage }}
-        run: vendor/bin/phpunit --coverage-clover coverage.xml
+        run: vendor/bin/phpunit --coverage-clover coverage.xml ${{ matrix.fail_on_deprecation && '--fail-on-deprecation --fail-on-notice' || '' }}
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.coverage }}

--- a/tests/Doctrine/Metrics/DbMetricRecorderTest.php
+++ b/tests/Doctrine/Metrics/DbMetricRecorderTest.php
@@ -128,7 +128,6 @@ final class DbMetricRecorderTest extends TestCase
 
         $reflection = new \ReflectionClass($recorder);
         $duration = $reflection->getProperty('duration');
-        $duration->setAccessible(true);
         $duration->setValue($recorder, $broken);
 
         $recorder->record('SELECT 1', hrtime(true), null);

--- a/tests/Doctrine/Middleware/MeteredDriverTest.php
+++ b/tests/Doctrine/Middleware/MeteredDriverTest.php
@@ -54,7 +54,6 @@ final class MeteredDriverTest extends TestCase
 
         $reflection = new \ReflectionClass(MeteredDriver::class);
         $method = $reflection->getMethod('resolveDbSystem');
-        $method->setAccessible(true);
 
         $driver = new MeteredDriver($inner, 'test');
         self::assertSame($expectedSystem, $method->invoke($driver, ['driver' => $driverName]));
@@ -67,7 +66,6 @@ final class MeteredDriverTest extends TestCase
 
         $reflection = new \ReflectionClass(MeteredDriver::class);
         $method = $reflection->getMethod('resolveDbSystem');
-        $method->setAccessible(true);
 
         $driver = new MeteredDriver($inner, 'test');
         self::assertSame('other_sql', $method->invoke($driver, []));

--- a/tests/EventSubscriber/OpenTelemetryMetricsSubscriberTest.php
+++ b/tests/EventSubscriber/OpenTelemetryMetricsSubscriberTest.php
@@ -323,7 +323,6 @@ final class OpenTelemetryMetricsSubscriberTest extends TestCase
 
         $reflection = new \ReflectionClass($this->subscriber);
         $property = $reflection->getProperty('activeRequests');
-        $property->setAccessible(true);
         $property->setValue($this->subscriber, $broken);
     }
 
@@ -334,7 +333,6 @@ final class OpenTelemetryMetricsSubscriberTest extends TestCase
 
         $reflection = new \ReflectionClass($this->subscriber);
         $property = $reflection->getProperty('duration');
-        $property->setAccessible(true);
         $property->setValue($this->subscriber, $broken);
     }
 }

--- a/tests/HttpClient/MeteredHttpClientTest.php
+++ b/tests/HttpClient/MeteredHttpClientTest.php
@@ -371,7 +371,6 @@ final class MeteredHttpClientTest extends TestCase
 
         $reflection = new \ReflectionClass($client);
         $duration = $reflection->getProperty('duration');
-        $duration->setAccessible(true);
         $duration->setValue($client, $broken);
     }
 
@@ -382,7 +381,6 @@ final class MeteredHttpClientTest extends TestCase
 
         $reflection = new \ReflectionClass($client);
         $requestBodySize = $reflection->getProperty('requestBodySize');
-        $requestBodySize->setAccessible(true);
         $requestBodySize->setValue($client, $broken);
     }
 
@@ -393,7 +391,6 @@ final class MeteredHttpClientTest extends TestCase
 
         $reflection = new \ReflectionClass($client);
         $inFlight = $reflection->getProperty('inFlight');
-        $inFlight->setAccessible(true);
         $inFlight->setValue($client, true);
 
         $response = $client->request('GET', 'https://api.example.com/data');
@@ -410,7 +407,6 @@ final class MeteredHttpClientTest extends TestCase
 
         $reflection = new \ReflectionClass($client);
         $inFlight = $reflection->getProperty('inFlight');
-        $inFlight->setAccessible(true);
         $inFlight->setValue($client, true);
 
         $client->reset();

--- a/tests/Messenger/OpenTelemetryMetricsMiddlewareTest.php
+++ b/tests/Messenger/OpenTelemetryMetricsMiddlewareTest.php
@@ -263,7 +263,6 @@ final class OpenTelemetryMetricsMiddlewareTest extends TestCase
 
         $reflection = new \ReflectionClass($middleware);
         $property = $reflection->getProperty('dispatchSent');
-        $property->setAccessible(true);
         $property->setValue($middleware, $broken);
     }
 
@@ -412,7 +411,6 @@ final class OpenTelemetryMetricsMiddlewareTest extends TestCase
 
         $reflection = new \ReflectionClass($middleware);
         $messages = $reflection->getProperty('messages');
-        $messages->setAccessible(true);
         $messages->setValue($middleware, $brokenCounter);
     }
 }


### PR DESCRIPTION
 ## Summary
  - Adds a PHP 8.5 row to the test matrix.
  - Runs PHPUnit with \`--fail-on-deprecation --fail-on-notice\` on that job so native PHP
  deprecations fail CI.
  - Motivated by #48 (SplObjectStorage::contains/detach deprecations), which only surfaced via user
  report.