### PR TITLE
Fix namespaced cache child definition detection

### DIFF
--- a/src/DependencyInjection/Compiler/CacheTracingPass.php
+++ b/src/DependencyInjection/Compiler/CacheTracingPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Traceway\OpenTelemetryBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -53,6 +54,10 @@ final class CacheTracingPass implements CompilerPassInterface
             \assert(\is_array($firstTag));
             $poolName = \is_string($firstTag['name'] ?? null) ? $firstTag['name'] : $id;
             $class = $definition->getClass();
+            while ($definition instanceof ChildDefinition) {
+                $definition = $container->findDefinition($definition->getParent());
+                $class ??= $definition->getClass();
+            }
 
             $isTagAware = null !== $class && is_subclass_of($class, TagAwareCacheInterface::class);
             $isNamespaced = !$isTagAware

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -7,6 +7,7 @@ namespace Traceway\OpenTelemetryBundle\Tests\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Contracts\Cache\NamespacedPoolInterface;
@@ -31,6 +32,32 @@ final class CacheTracingPassTest extends TestCase
         $pass->process($container);
 
         self::assertTrue($container->hasDefinition('cache.app.otel'));
+
+        $decorator = $container->getDefinition('cache.app.otel');
+        $expectedClass = interface_exists(NamespacedPoolInterface::class) && is_subclass_of(FilesystemAdapter::class, NamespacedPoolInterface::class)
+            ? TraceableNamespacedCachePool::class
+            : TraceableCachePool::class;
+        self::assertSame($expectedClass, $decorator->getClass());
+        self::assertSame('test-tracer', $decorator->getArgument('$tracerName'));
+        self::assertSame('cache.app', $decorator->getArgument('$poolName'));
+    }
+
+    public function testDecoratesCachePoolDefinedAsChildDefinition(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('open_telemetry.cache_enabled', true);
+        $container->setParameter('open_telemetry.tracer_name', 'test-tracer');
+
+        $adapterDef = new Definition(FilesystemAdapter::class);
+        $adapterDef->setAbstract(true);
+        $container->setDefinition('cache.adapter.filesystem', $adapterDef);
+
+        $poolDef = new ChildDefinition('cache.adapter.filesystem');
+        $poolDef->addTag('cache.pool', ['name' => 'cache.app']);
+        $container->setDefinition('cache.app', $poolDef);
+
+        $pass = new CacheTracingPass();
+        $pass->process($container);
 
         $decorator = $container->getDefinition('cache.app.otel');
         $expectedClass = interface_exists(NamespacedPoolInterface::class) && is_subclass_of(FilesystemAdapter::class, NamespacedPoolInterface::class)


### PR DESCRIPTION
Hi, everyone! Got an error in my production build, when bundle didn't use TraceableNamespacedCachePool for cache pools defined through Symfony ChildDefinition. 

Here is the original error that i've had
```
{
    "message": "Error thrown while running command \"lint:container\". Message: \"Invalid alias definition: alias \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\" is referencing class \"Traceway\\OpenTelemetryBundle\\Cache\\TraceableCachePool\" but this class does not implement \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\". Because this alias is an interface, \"Traceway\\OpenTelemetryBundle\\Cache\\TraceableCachePool\" must implement \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\".\"",
    "context": {
        "exception": {
            "class": "Symfony\\Component\\DependencyInjection\\Exception\\RuntimeException",
            "message": "Invalid alias definition: alias \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\" is referencing class \"Traceway\\OpenTelemetryBundle\\Cache\\TraceableCachePool\" but this class does not implement \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\". Because this alias is an interface, \"Traceway\\OpenTelemetryBundle\\Cache\\TraceableCachePool\" must implement \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\".",
            "code": 0,
            "file": "/var/www/vendor/symfony/dependency-injection/Compiler/CheckAliasValidityPass.php:44"
        },
        "command": "lint:container",
        "message": "Invalid alias definition: alias \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\" is referencing class \"Traceway\\OpenTelemetryBundle\\Cache\\TraceableCachePool\" but this class does not implement \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\". Because this alias is an interface, \"Traceway\\OpenTelemetryBundle\\Cache\\TraceableCachePool\" must implement \"Symfony\\Contracts\\Cache\\NamespacedPoolInterface\"."
    },
    "level": 500,
    "level_name": "CRITICAL",
    "channel": "console",
    "datetime": "2026-06-10T15:21:13.381054+00:00",
    "extra": {
        "trace_id": "1203947cde9b860b9cce7568b62ee4b6",
        "span_id": "3f77c6464430e113"
    }
}
```