### PR TITLE
fix: cache:pool:prune fatals on a traced cache pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cache:pool:prune` no longer fatals on a traced cache pool** - `TraceableCachePool` now implements `PruneableInterface` and delegates `prune()` to the inner pool. The prunable `cache.pool` tag transfers onto the decorator, so `CachePoolPrunerPass` selects it and the command called the missing `prune()` (`Call to undefined method ...::prune()`) on every scheduled run against a DB-backed pool. Mirrors Symfony's `TraceableAdapter` (returns `false` when the pool is not prunable); the `TraceableTagAwareCachePool`/`TraceableNamespacedCachePool` subclasses inherit it.
+
 ## [3.0.0] - 2026-06-15
 
 This is a **conformance major**: a full pass aligning every instrumentation with the current *stable* OpenTelemetry semantic conventions. There are no API changes for application code — the breaking changes are span-name, attribute-key, attribute-value, metric-bucket, and one config-validation change that mostly cause dashboards/alerts to regroup. See [UPGRADE-3.0.md](UPGRADE-3.0.md) for the full migration checklist. **Legacy flat config keys still work in 3.0** (removal deferred to 4.0 — see [UPGRADE-2.0.md](UPGRADE-2.0.md#timeline)).

--- a/src/Cache/TraceableCachePool.php
+++ b/src/Cache/TraceableCachePool.php
@@ -12,6 +12,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -27,7 +28,7 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  * Implements AdapterInterface so Symfony's profiler TraceableAdapter
  * can safely wrap this decorator in dev mode.
  */
-class TraceableCachePool implements CacheInterface, AdapterInterface, ResetInterface
+class TraceableCachePool implements CacheInterface, AdapterInterface, PruneableInterface, ResetInterface
 {
     private ?TracerInterface $tracer = null;
     private ?bool $enabled = null;
@@ -190,6 +191,11 @@ class TraceableCachePool implements CacheInterface, AdapterInterface, ResetInter
     public function commit(): bool
     {
         return $this->pool->commit();
+    }
+
+    public function prune(): bool
+    {
+        return $this->pool instanceof PruneableInterface ? $this->pool->prune() : false;
     }
 
     public function reset(): void

--- a/tests/Cache/TraceableCachePoolTest.php
+++ b/tests/Cache/TraceableCachePoolTest.php
@@ -11,6 +11,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -175,6 +176,40 @@ final class TraceableCachePoolTest extends TestCase
         $pool->hasItem('key');
         $pool->deleteItem('key');
 
+        self::assertEmpty($this->exporter->getSpans());
+    }
+
+    public function testPruneDelegatesToPruneablePool(): void
+    {
+        $inner = new class implements AdapterInterface, CacheInterface, PruneableInterface {
+            public bool $pruned = false;
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed { return null; }
+            public function delete(string $key): bool { return true; }
+            public function getItem(mixed $key): CacheItem { throw new \LogicException('Not implemented'); }
+            public function getItems(array $keys = []): iterable { return []; }
+            public function hasItem(mixed $key): bool { return false; }
+            public function clear(string $prefix = ''): bool { return true; }
+            public function deleteItem(string $key): bool { return true; }
+            public function deleteItems(array $keys): bool { return true; }
+            public function save(CacheItemInterface $item): bool { return true; }
+            public function saveDeferred(CacheItemInterface $item): bool { return true; }
+            public function commit(): bool { return true; }
+            public function prune(): bool { $this->pruned = true; return true; }
+        };
+
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+
+        self::assertTrue($pool->prune());
+        self::assertTrue($inner->pruned);
+        self::assertEmpty($this->exporter->getSpans());
+    }
+
+    public function testPruneReturnsFalseForNonPruneablePool(): void
+    {
+        $inner = $this->createCachePool('value', true);
+        $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');
+
+        self::assertFalse($pool->prune());
         self::assertEmpty($this->exporter->getSpans());
     }
 

--- a/tests/Cache/TraceableCachePoolTest.php
+++ b/tests/Cache/TraceableCachePoolTest.php
@@ -183,18 +183,68 @@ final class TraceableCachePoolTest extends TestCase
     {
         $inner = new class implements AdapterInterface, CacheInterface, PruneableInterface {
             public bool $pruned = false;
-            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed { return null; }
-            public function delete(string $key): bool { return true; }
-            public function getItem(mixed $key): CacheItem { throw new \LogicException('Not implemented'); }
-            public function getItems(array $keys = []): iterable { return []; }
-            public function hasItem(mixed $key): bool { return false; }
-            public function clear(string $prefix = ''): bool { return true; }
-            public function deleteItem(string $key): bool { return true; }
-            public function deleteItems(array $keys): bool { return true; }
-            public function save(CacheItemInterface $item): bool { return true; }
-            public function saveDeferred(CacheItemInterface $item): bool { return true; }
-            public function commit(): bool { return true; }
-            public function prune(): bool { $this->pruned = true; return true; }
+
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+            {
+                return null;
+            }
+
+            public function delete(string $key): bool
+            {
+                return true;
+            }
+
+            public function getItem(mixed $key): CacheItem
+            {
+                throw new \LogicException('Not implemented');
+            }
+
+            public function getItems(array $keys = []): iterable
+            {
+                return [];
+            }
+
+            public function hasItem(mixed $key): bool
+            {
+                return false;
+            }
+
+            public function clear(string $prefix = ''): bool
+            {
+                return true;
+            }
+
+            public function deleteItem(string $key): bool
+            {
+                return true;
+            }
+
+            public function deleteItems(array $keys): bool
+            {
+                return true;
+            }
+
+            public function save(CacheItemInterface $item): bool
+            {
+                return true;
+            }
+
+            public function saveDeferred(CacheItemInterface $item): bool
+            {
+                return true;
+            }
+
+            public function commit(): bool
+            {
+                return true;
+            }
+
+            public function prune(): bool
+            {
+                $this->pruned = true;
+
+                return true;
+            }
         };
 
         $pool = new TraceableCachePool($inner, 'test-tracer', 'cache.app');


### PR DESCRIPTION
`cache:pool:prune` fails with a fatal error when cache tracing is enabled (the default) and a prunable pool is configured - typically a DB-backed app cache. Since the command is usually run on a schedule, it surfaces as a recurring failure of the cleanup job rather than an interactive error.

The cause: Symfony tags prunable pools, and when a pool is wrapped for tracing, that tag is transferred onto `TraceableCachePool`. Symfony's pruner then selects the decorator and calls `prune()` on it - a method the decorator did not implement, resulting in `Call to undefined method ...TraceableCachePool::prune()`.

The fix follows Symfony's own `TraceableAdapter`: `TraceableCachePool` now implements `PruneableInterface` and delegates `prune()` to the wrapped pool, returning `false` when that pool is not prunable. The tag-aware and namespaced variants inherit the behaviour.

Two tests cover it - delegation to a prunable pool, and `false` for a non-prunable one. Full suite passes, PHPStan level 10 clean.

Fixes #56.
