### PR TITLE
Fix Symfony profiler wrapping for tag-aware cache pools

### DIFF
--- a/src/Cache/TraceableTagAwareCachePool.php
+++ b/src/Cache/TraceableTagAwareCachePool.php
@@ -7,6 +7,7 @@ namespace Traceway\OpenTelemetryBundle\Cache;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 
@@ -14,7 +15,7 @@ use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
  * Extends {@see TraceableCachePool} for tag-aware cache pools,
  * adding a span for invalidateTags().
  */
-final class TraceableTagAwareCachePool extends TraceableCachePool implements TagAwareCacheInterface
+final class TraceableTagAwareCachePool extends TraceableCachePool implements TagAwareCacheInterface, TagAwareAdapterInterface
 {
     private readonly TagAwareCacheInterface $tagAwarePool;
 

--- a/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
+++ b/tests/DependencyInjection/Compiler/CacheTracingPassTest.php
@@ -7,6 +7,9 @@ namespace Traceway\OpenTelemetryBundle\Tests\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TraceableTagAwareAdapter;
+use Symfony\Component\Cache\DataCollector\CacheDataCollector;
+use Symfony\Component\Cache\DependencyInjection\CacheCollectorPass;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -85,6 +88,22 @@ final class CacheTracingPassTest extends TestCase
 
         $decorator = $container->getDefinition('cache.app.taggable.otel');
         self::assertSame(TraceableTagAwareCachePool::class, $decorator->getClass());
+    }
+
+    public function testSymfonyProfilerKeepsTraceableTagAwarePoolTagAware(): void
+    {
+        $container = new ContainerBuilder();
+
+        $poolDef = new Definition(TraceableTagAwareCachePool::class);
+        $poolDef->addTag('cache.pool', ['name' => 'cache.app.taggable']);
+        $container->setDefinition('cache.app.taggable', $poolDef);
+        $container->setDefinition('data_collector.cache', new Definition(CacheDataCollector::class));
+
+        $collectorPass = new CacheCollectorPass();
+        $collectorPass->process($container);
+
+        $decorator = $container->getDefinition('cache.app.taggable');
+        self::assertSame(TraceableTagAwareAdapter::class, $decorator->getClass());
     }
 
     public function testSkipsWhenDisabled(): void


### PR DESCRIPTION
Hi, everyone! Got an error in my tests, when added bundle to my new project. The problem is that Symfony’s `CacheCollectorPass` [checks for](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php#L50) `TagAwareAdapterInterface` when deciding to wrap a cache pool with `TraceableTagAwareAdapter` or `TraceableAdapter`, but `TraceableTagAwareCachePool` doesn't implement `TagAwareAdapterInterface`.


Here is the error that i had:
```
{
    "error": {
        "title": "Server error",
        "status": 500,
        "errorCode": null,
        "detail": "App\\User\\Service\\UserService::__construct(): Argument #3 ($appCacheUser) must be of type Symfony\\Contracts\\Cache\\TagAwareCacheInterface, Symfony\\Component\\Cache\\Adapter\\TraceableAdapter given, called in /var/www/var/cache/test/ContainerAbJwkYx/App_KernelTestDebugContainer.php on line 7847"
    }
}
```