### PR TITLE
Fix default_bus usage in messenger if config has it

### DIFF
--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -54,10 +54,12 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
                 $middlewares[] = OpenTelemetryMetricsMiddleware::class;
             }
             if ([] !== $middlewares) {
+                $busName = $this->getMessengerDefaultBusName($container);
+
                 $container->prependExtensionConfig('framework', [
                     'messenger' => [
                         'buses' => [
-                            'messenger.bus.default' => [
+                            $busName => [
                                 'middleware' => $middlewares,
                             ],
                         ],
@@ -327,5 +329,24 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
     private function isXRayAvailable(): bool
     {
         return class_exists(\OpenTelemetry\Contrib\Aws\Xray\Propagator::class);
+    }
+
+    private function getMessengerDefaultBusName(ContainerBuilder $container): string
+    {
+        $busName = null;
+
+        foreach ($container->getExtensionConfig('framework') as $frameworkConfig) {
+            if (!isset($frameworkConfig['messenger']) || !\is_array($frameworkConfig['messenger'])) {
+                continue;
+            }
+
+            $defaultBus = $frameworkConfig['messenger']['default_bus'] ?? null;
+
+            if (\is_string($defaultBus) && '' !== $defaultBus) {
+                $busName = $defaultBus;
+            }
+        }
+
+        return $busName ?? 'messenger.bus.default';
     }
 }

--- a/tests/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -148,6 +148,29 @@ final class OpenTelemetryExtensionTest extends TestCase
         self::assertContains(OpenTelemetryMiddleware::class, $middleware);
     }
 
+    public function testPrependRegistersMessengerMiddlewareOnConfiguredDefaultBus(): void
+    {
+        $container = new ContainerBuilder();
+        $container->prependExtensionConfig('framework', [
+            'messenger' => [
+                'default_bus' => 'messenger.bus.commands',
+            ],
+        ]);
+
+        $extension = new OpenTelemetryExtension();
+        $extension->prepend($container);
+
+        $frameworkConfigs = $container->getExtensionConfig('framework');
+        self::assertNotEmpty($frameworkConfigs);
+
+        $messengerConfig = $frameworkConfigs[0]['messenger'] ?? null;
+        self::assertNotNull($messengerConfig);
+
+        $middleware = $messengerConfig['buses']['messenger.bus.commands']['middleware'] ?? [];
+        self::assertContains(OpenTelemetryMiddleware::class, $middleware);
+        self::assertArrayNotHasKey('messenger.bus.default', $messengerConfig['buses']);
+    }
+
     public function testPrependSkippedWhenMessengerDisabled(): void
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
Hi, everyone! Symfony messenger has `default_bus` [option](https://symfony.com/doc/current/messenger.html#multiple-buses-command-event-buses). Right now bundle ignores it and prepends middleware to `messenger.bus.default`. Because of that, those who use `default_bus` need to prepend middleware manually in their config