### PR TITLE
Fix traces.enabled as master switch for trace instrumentation

### DIFF
--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -41,12 +41,14 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
     public function prepend(ContainerBuilder $container): void
     {
         $configs = $container->getExtensionConfig($this->getAlias());
-        /** @var array{traces: array{messenger: array{enabled: bool}}, metrics: array{enabled: bool, messenger: array{enabled: bool}}, logs: array{export: array{enabled: bool, level: string, capture_code_attributes: bool, unprefixed_attributes: bool}}} $config */
+        /** @var array{traces: array{enabled: bool, messenger: array{enabled: bool}}, metrics: array{enabled: bool, messenger: array{enabled: bool}}, logs: array{export: array{enabled: bool, level: string, capture_code_attributes: bool, unprefixed_attributes: bool}}} $config */
         $config = $this->processConfiguration(new Configuration(), $configs);
+
+        $tracingEnabled = $config['traces']['enabled'];
 
         if ($this->isMessengerAvailable()) {
             $middlewares = [];
-            if ($config['traces']['messenger']['enabled']) {
+            if ($tracingEnabled && $config['traces']['messenger']['enabled']) {
                 $middlewares[] = OpenTelemetryMiddleware::class;
             }
             $metrics = $config['metrics'];
@@ -105,19 +107,21 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
         $sdk = $config['sdk'];
 
         $traces = $config['traces'];
+        $tracingEnabled = $traces['enabled'];
         $tracerName = $traces['tracer_name'];
 
         $container->getDefinition(Tracing::class)
             ->setArgument('$tracerName', $tracerName);
 
-        $httpClientEnabled = $traces['http_client']['enabled'] && $this->isHttpClientAvailable();
+        $httpClientEnabled = $tracingEnabled && $traces['http_client']['enabled'] && $this->isHttpClientAvailable();
+        $messengerTracingEnabled = $tracingEnabled && $traces['messenger']['enabled'];
         $container->setParameter('open_telemetry.http_client_enabled', $httpClientEnabled);
         $container->setParameter('open_telemetry.tracer_name', $tracerName);
 
-        $container->setParameter('open_telemetry.traces.enabled', $traces['enabled']);
+        $container->setParameter('open_telemetry.traces.enabled', $tracingEnabled);
         $container->setParameter('open_telemetry.traces.propagator', $traces['propagator']);
         $container->setParameter('open_telemetry.traces.id_generator', $traces['id_generator']);
-        $container->setParameter('open_telemetry.traces.messenger.enabled', $traces['messenger']['enabled']);
+        $container->setParameter('open_telemetry.traces.messenger.enabled', $messengerTracingEnabled);
         $container->setParameter('open_telemetry.metrics.enabled', $config['metrics']['enabled']);
         $container->setParameter('open_telemetry.logs.export.enabled', $config['logs']['export']['enabled']);
 
@@ -129,7 +133,7 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->setParameter('open_telemetry.sdk.config', $sdk);
         }
 
-        if ($traces['enabled']) {
+        if ($tracingEnabled) {
             $container->getDefinition(OpenTelemetrySubscriber::class)
                 ->setArgument('$tracerName', $tracerName)
                 ->setArgument('$excludedPaths', $traces['excluded_paths'])
@@ -139,7 +143,7 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->removeDefinition(OpenTelemetrySubscriber::class);
         }
 
-        if ($traces['console']['enabled'] && $this->isConsoleAvailable()) {
+        if ($tracingEnabled && $traces['console']['enabled'] && $this->isConsoleAvailable()) {
             $container->getDefinition(ConsoleSubscriber::class)
                 ->setArgument('$tracerName', $tracerName)
                 ->setArgument('$excludedCommands', $traces['console']['excluded_commands']);
@@ -147,9 +151,9 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->removeDefinition(ConsoleSubscriber::class);
         }
 
-        $schedulerEnabled = $traces['scheduler']['enabled'] && $this->isSchedulerAvailable();
+        $schedulerEnabled = $tracingEnabled && $traces['scheduler']['enabled'] && $this->isSchedulerAvailable();
 
-        if ($traces['messenger']['enabled'] && $this->isMessengerAvailable()) {
+        if ($messengerTracingEnabled && $this->isMessengerAvailable()) {
             $container->getDefinition(OpenTelemetryMiddleware::class)
                 ->setArgument('$tracerName', $tracerName)
                 ->setArgument('$rootSpans', $traces['messenger']['root_spans'])
@@ -165,7 +169,7 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->setDefinition(SchedulerSubscriber::class, $schedulerDef);
         }
 
-        if ($traces['doctrine']['enabled'] && $this->isDoctrineAvailable()) {
+        if ($tracingEnabled && $traces['doctrine']['enabled'] && $this->isDoctrineAvailable()) {
             $definition = new Definition(DoctrineTraceableMiddleware::class);
             $definition->setArgument('$tracerName', $tracerName);
             $definition->setArgument('$recordStatements', $traces['doctrine']['record_statements']);
@@ -173,13 +177,13 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->setDefinition(DoctrineTraceableMiddleware::class, $definition);
         }
 
-        $cacheEnabled = $traces['cache']['enabled'] && $this->isCacheAvailable();
+        $cacheEnabled = $tracingEnabled && $traces['cache']['enabled'] && $this->isCacheAvailable();
         $container->setParameter('open_telemetry.cache_enabled', $cacheEnabled);
         /** @var string[] $cacheExcludedPools */
         $cacheExcludedPools = $traces['cache']['excluded_pools'];
         $container->setParameter('open_telemetry.cache_excluded_pools', $cacheExcludedPools);
 
-        if ($traces['twig']['enabled'] && $this->isTwigAvailable()) {
+        if ($tracingEnabled && $traces['twig']['enabled'] && $this->isTwigAvailable()) {
             /** @var string[] $twigExcluded */
             $twigExcluded = $traces['twig']['excluded_templates'];
             $twigExtDef = new Definition(OpenTelemetryTwigExtension::class);
@@ -190,7 +194,7 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
             $container->setDefinition(OpenTelemetryTwigExtension::class, $twigExtDef);
         }
 
-        if ($traces['mailer']['enabled'] && $this->isMailerAvailable()) {
+        if ($tracingEnabled && $traces['mailer']['enabled'] && $this->isMailerAvailable()) {
             $mailerDef = new Definition(TraceableMailer::class);
             $mailerDef->setDecoratedService('mailer.mailer', null, 0, ContainerInterface::IGNORE_ON_INVALID_REFERENCE);
             $mailerDef->setArgument('$decorated', new Reference('.inner'));

--- a/tests/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -11,6 +11,9 @@ use Traceway\OpenTelemetryBundle\Doctrine\Middleware\TraceableMiddleware as Doct
 use Traceway\OpenTelemetryBundle\EventSubscriber\ConsoleSubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OpenTelemetrySubscriber;
 use Traceway\OpenTelemetryBundle\EventSubscriber\OtelLoggerFlushSubscriber;
+use Traceway\OpenTelemetryBundle\EventSubscriber\SchedulerSubscriber;
+use Traceway\OpenTelemetryBundle\Mailer\TraceableMailer;
+use Traceway\OpenTelemetryBundle\Mailer\TraceableTransports;
 use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
 use Traceway\OpenTelemetryBundle\Monolog\OtelLogHandler;
 use Traceway\OpenTelemetryBundle\Monolog\TraceContextProcessor;
@@ -71,6 +74,36 @@ final class OpenTelemetryExtensionTest extends TestCase
 
         self::assertFalse($container->hasDefinition(OpenTelemetrySubscriber::class));
         self::assertTrue($container->hasDefinition(Tracing::class));
+    }
+
+    public function testTraceSubsystemsDisabledWhenTracesDisabled(): void
+    {
+        $container = $this->buildContainer([
+            'traces' => [
+                'enabled' => false,
+                'http_client' => ['enabled' => true],
+                'console' => ['enabled' => true],
+                'messenger' => ['enabled' => true],
+                'doctrine' => ['enabled' => true],
+                'cache' => ['enabled' => true],
+                'twig' => ['enabled' => true],
+                'scheduler' => ['enabled' => true],
+                'mailer' => ['enabled' => true],
+            ],
+        ]);
+
+        self::assertFalse($container->getParameter('open_telemetry.http_client_enabled'));
+        self::assertFalse($container->getParameter('open_telemetry.traces.messenger.enabled'));
+        self::assertFalse($container->getParameter('open_telemetry.cache_enabled'));
+
+        self::assertFalse($container->hasDefinition(OpenTelemetrySubscriber::class));
+        self::assertFalse($container->hasDefinition(ConsoleSubscriber::class));
+        self::assertFalse($container->hasDefinition(OpenTelemetryMiddleware::class));
+        self::assertFalse($container->hasDefinition(DoctrineTraceableMiddleware::class));
+        self::assertFalse($container->hasDefinition(OpenTelemetryTwigExtension::class));
+        self::assertFalse($container->hasDefinition(SchedulerSubscriber::class));
+        self::assertFalse($container->hasDefinition(TraceableMailer::class));
+        self::assertFalse($container->hasDefinition(TraceableTransports::class));
     }
 
     public function testConsoleSubscriberRemovedWhenDisabled(): void
@@ -152,6 +185,23 @@ final class OpenTelemetryExtensionTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->prependExtensionConfig('open_telemetry', ['traces' => ['messenger' => ['enabled' => false]]]);
+
+        $extension = new OpenTelemetryExtension();
+        $extension->prepend($container);
+
+        $frameworkConfigs = $container->getExtensionConfig('framework');
+        self::assertEmpty($frameworkConfigs);
+    }
+
+    public function testPrependSkippedWhenTracesDisabled(): void
+    {
+        $container = new ContainerBuilder();
+        $container->prependExtensionConfig('open_telemetry', [
+            'traces' => [
+                'enabled' => false,
+                'messenger' => ['enabled' => true],
+            ],
+        ]);
 
         $extension = new OpenTelemetryExtension();
         $extension->prepend($container);


### PR DESCRIPTION
Hi, everyone! When I hit the problem described in [this PR](https://github.com/tracewayapp/opentelemetry-symfony-bundle/pull/59) , I noticed, that when `traces.enabled=false` the subsystems of tracing, like `traces.cache`, `traces.messenger` and others,  are not actually disabled and to disable them completely in test env, I had to have a config like this:
```
when@test:
    open_telemetry:
        traces:
            enabled: false
            console:
                enabled: false
            http_client:
                enabled: false
            messenger:
                enabled: false
            scheduler:
                enabled: false
            mailer:
                enabled: false
            doctrine:
                enabled: false
            cache:
                enabled: false
            twig:
                enabled: false

```

I propose changing this behaviour, so that `traces.enabled` work as a master switch for all suboptions. With this we'll be able to use config like this to disable tracing in test env:
```
when@test:
    open_telemetry:
        traces:
            enabled: false
```