### PR TITLE
Fix streamable traced responses

### DIFF
--- a/src/HttpClient/TracedResponse.php
+++ b/src/HttpClient/TracedResponse.php
@@ -12,6 +12,7 @@ use OpenTelemetry\SemConv\Attributes\NetworkAttributes;
 use OpenTelemetry\SemConv\Attributes\ServerAttributes;
 use OpenTelemetry\SemConv\Attributes\UrlAttributes;
 use OpenTelemetry\SemConv\Incubating\Attributes\HttpIncubatingAttributes;
+use Symfony\Component\HttpClient\Response\StreamableInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Traceway\OpenTelemetryBundle\Util\ErrorTypeResolver;
 use Traceway\OpenTelemetryBundle\Util\UrlSanitizer;
@@ -24,7 +25,7 @@ use Traceway\OpenTelemetryBundle\Util\UrlSanitizer;
  * wrapper ensures the span captures the real status code and ends at the
  * right time.
  */
-final class TracedResponse implements ResponseInterface
+final class TracedResponse implements ResponseInterface, StreamableInterface
 {
     private bool $spanEnded = false;
 
@@ -111,6 +112,31 @@ final class TracedResponse implements ResponseInterface
     public function getInfo(?string $type = null): mixed
     {
         return $this->response->getInfo($type);
+    }
+
+    /**
+     * @return resource
+     */
+    public function toStream(bool $throw = true)
+    {
+        try {
+            if ($throw) {
+                $this->response->getHeaders(true);
+            }
+
+            if (!$this->response instanceof StreamableInterface) {
+                throw new \LogicException('Response does not implement StreamableInterface.');
+            }
+
+            $stream = $this->response->toStream(false);
+        } catch (\Throwable $e) {
+            $this->finalizeSpanWithError($e);
+            throw $e;
+        }
+
+        $this->safeFinalize();
+
+        return $stream;
     }
 
     public function getInnerResponse(): ResponseInterface

--- a/tests/HttpClient/TracedResponseTest.php
+++ b/tests/HttpClient/TracedResponseTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Traceway\OpenTelemetryBundle\Tests\HttpClient;
 
+use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\StatusCode;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Traceway\OpenTelemetryBundle\HttpClient\TraceableHttpClient;
 use Traceway\OpenTelemetryBundle\HttpClient\TracedResponse;
 use Traceway\OpenTelemetryBundle\Tests\OTelTestTrait;
@@ -226,6 +228,25 @@ final class TracedResponseTest extends TestCase
             $response->toStream(true);
             self::fail('Expected exception');
         } catch (\Throwable) {
+        }
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        self::assertSame(StatusCode::STATUS_ERROR, $spans[0]->getStatus()->getCode());
+        self::assertNotEmpty($spans[0]->getEvents());
+        self::assertSame('exception', $spans[0]->getEvents()[0]->getName());
+    }
+
+    public function testToStreamThrowsAndRecordsExceptionForNonStreamableInnerResponse(): void
+    {
+        $span = Globals::tracerProvider()->getTracer('test')->spanBuilder('GET')->startSpan();
+        $response = new TracedResponse($this->createStub(ResponseInterface::class), $span);
+
+        try {
+            $response->toStream(false);
+            self::fail('Expected exception');
+        } catch (\LogicException $e) {
+            self::assertSame('Response does not implement StreamableInterface.', $e->getMessage());
         }
 
         $spans = $this->exporter->getSpans();

--- a/tests/HttpClient/TracedResponseTest.php
+++ b/tests/HttpClient/TracedResponseTest.php
@@ -66,6 +66,22 @@ final class TracedResponseTest extends TestCase
         self::assertSame(5, $attributes['http.response.body.size']);
     }
 
+    public function testToStreamReturnsSeekableStreamAndFinalizesSpan(): void
+    {
+        $response = $this->makeResponse(200, 'streamed');
+
+        $stream = $response->toStream(false);
+
+        self::assertIsResource($stream);
+        self::assertSame('streamed', stream_get_contents($stream));
+        self::assertSame(0, fseek($stream, 0));
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        $attributes = $spans[0]->getAttributes()->toArray();
+        self::assertSame(200, $attributes['http.response.status_code']);
+    }
+
     public function testToArrayFinalizesSpan(): void
     {
         $body = '{"key":"value"}';
@@ -191,6 +207,23 @@ final class TracedResponseTest extends TestCase
 
         try {
             $response->getContent(true);
+            self::fail('Expected exception');
+        } catch (\Throwable) {
+        }
+
+        $spans = $this->exporter->getSpans();
+        self::assertCount(1, $spans);
+        self::assertSame(StatusCode::STATUS_ERROR, $spans[0]->getStatus()->getCode());
+        self::assertNotEmpty($spans[0]->getEvents());
+        self::assertSame('exception', $spans[0]->getEvents()[0]->getName());
+    }
+
+    public function testToStreamThrowsOnErrorAndRecordsException(): void
+    {
+        $response = $this->makeResponse(500, 'Server Error');
+
+        try {
+            $response->toStream(true);
             self::fail('Expected exception');
         } catch (\Throwable) {
         }


### PR DESCRIPTION
Hi, everyone! Had a new error in my project.  The cause was `TracedResponse` implementing only `ResponseInterface`, while Symfony’s Responses also implement `StreamableInterface` and check for it in `toStream` [method](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpClient/Response/TraceableResponse.php#L147-L159). If the check fails Symfony returns lazy `StreamWrapper`, which was not expected