### PR TITLE
Fix messenger middleware merge

### DIFF
--- a/src/DependencyInjection/Compiler/MessengerMiddlewarePass.php
+++ b/src/DependencyInjection/Compiler/MessengerMiddlewarePass.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMetricsMiddleware;
+use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
+
+/**
+ * Adds Traceway middleware to the normalized Messenger middleware parameter.
+ *
+ * FrameworkBundle creates the "<bus id>.middleware" parameter before compiler
+ * passes run, and MessengerPass consumes it later in the same phase. Mutating
+ * the parameter here avoids framework config list-merge semantics.
+ */
+final class MessengerMiddlewarePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $busId = $this->resolveDefaultBusId($container);
+        if (null === $busId) {
+            return;
+        }
+
+        $parameter = $busId.'.middleware';
+        if (!$container->hasParameter($parameter)) {
+            return;
+        }
+
+        $middleware = $container->getParameter($parameter);
+        if (!\is_array($middleware)) {
+            return;
+        }
+
+        if ($container->has(OpenTelemetryMiddleware::class)) {
+            $middleware = $this->insertMiddleware($middleware, OpenTelemetryMiddleware::class);
+        }
+
+        if ($this->isMetricsEnabled($container) && $container->has(OpenTelemetryMetricsMiddleware::class)) {
+            $middleware = $this->insertMiddleware($middleware, OpenTelemetryMetricsMiddleware::class);
+        }
+
+        $container->setParameter($parameter, $middleware);
+    }
+
+    private function resolveDefaultBusId(ContainerBuilder $container): ?string
+    {
+        if ($container->hasAlias('messenger.default_bus')) {
+            return (string) $container->getAlias('messenger.default_bus');
+        }
+
+        $busIds = array_keys($container->findTaggedServiceIds('messenger.bus'));
+        if (1 === \count($busIds)) {
+            return $busIds[0];
+        }
+
+        if ($container->hasParameter('messenger.bus.default.middleware')) {
+            return 'messenger.bus.default';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $middleware
+     *
+     * @return array<int|string, mixed>
+     */
+    private function insertMiddleware(array $middleware, string $serviceId): array
+    {
+        if ($this->hasMiddleware($middleware, $serviceId)) {
+            return $middleware;
+        }
+
+        $position = $this->findTerminalMiddlewarePosition($middleware);
+        array_splice($middleware, $position, 0, [['id' => $serviceId]]);
+
+        return $middleware;
+    }
+
+    /**
+     * @param array<int|string, mixed> $middleware
+     */
+    private function hasMiddleware(array $middleware, string $serviceId): bool
+    {
+        foreach ($middleware as $item) {
+            $id = $this->middlewareId($item);
+            if ($serviceId === $id || 'messenger.middleware.'.$serviceId === $id) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $middleware
+     */
+    private function findTerminalMiddlewarePosition(array $middleware): int
+    {
+        foreach ($middleware as $position => $item) {
+            if (\in_array($this->middlewareId($item), [
+                'send_message',
+                'messenger.middleware.send_message',
+                'handle_message',
+                'messenger.middleware.handle_message',
+            ], true)) {
+                return (int) $position;
+            }
+        }
+
+        return \count($middleware);
+    }
+
+    private function middlewareId(mixed $item): ?string
+    {
+        if (\is_string($item)) {
+            return $item;
+        }
+
+        if (!\is_array($item) || !isset($item['id'])) {
+            return null;
+        }
+
+        return \is_string($item['id']) ? $item['id'] : null;
+    }
+
+    private function isMetricsEnabled(ContainerBuilder $container): bool
+    {
+        if (!$container->hasParameter('open_telemetry.metrics.enabled')) {
+            return false;
+        }
+
+        return true === $container->getParameter('open_telemetry.metrics.enabled');
+    }
+}

--- a/src/DependencyInjection/Compiler/MessengerMiddlewarePass.php
+++ b/src/DependencyInjection/Compiler/MessengerMiddlewarePass.php
@@ -18,122 +18,68 @@ use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
  */
 final class MessengerMiddlewarePass implements CompilerPassInterface
 {
+    private const OPENTELEMETRY_MIDDLEWARE_IDS = [
+        OpenTelemetryMiddleware::class,
+        OpenTelemetryMetricsMiddleware::class,
+    ];
+
+    private const TERMINAL_MIDDLEWARE_IDS = [
+        'send_message',
+        'messenger.middleware.send_message',
+        'handle_message',
+        'messenger.middleware.handle_message',
+    ];
+
     public function process(ContainerBuilder $container): void
     {
-        $busId = $this->resolveDefaultBusId($container);
-        if (null === $busId) {
+        if (!$container->hasAlias('messenger.default_bus')) {
             return;
         }
 
-        $parameter = $busId.'.middleware';
+        $parameter = $container->getAlias('messenger.default_bus').'.middleware';
         if (!$container->hasParameter($parameter)) {
             return;
         }
 
-        $middleware = $container->getParameter($parameter);
-        if (!\is_array($middleware)) {
+        /** @var list<array{id: string, arguments?: array<int|string, mixed>}> $middlewares */
+        $middlewares = $container->getParameter($parameter);
+        $middlewareIds = array_column($middlewares, 'id');
+        $middlewareToInsert = [];
+
+        foreach (self::OPENTELEMETRY_MIDDLEWARE_IDS as $serviceId) {
+            if (!$container->has($serviceId)) {
+                continue;
+            }
+
+            if (\in_array($serviceId, $middlewareIds, true)) {
+                continue;
+            }
+
+            if (\in_array('messenger.middleware.'.$serviceId, $middlewareIds, true)) {
+                continue;
+            }
+
+            $middlewareToInsert[] = ['id' => $serviceId];
+        }
+
+        if ([] === $middlewareToInsert) {
             return;
         }
 
-        if ($container->has(OpenTelemetryMiddleware::class)) {
-            $middleware = $this->insertMiddleware($middleware, OpenTelemetryMiddleware::class);
-        }
-
-        if ($this->isMetricsEnabled($container) && $container->has(OpenTelemetryMetricsMiddleware::class)) {
-            $middleware = $this->insertMiddleware($middleware, OpenTelemetryMetricsMiddleware::class);
-        }
-
-        $container->setParameter($parameter, $middleware);
-    }
-
-    private function resolveDefaultBusId(ContainerBuilder $container): ?string
-    {
-        if ($container->hasAlias('messenger.default_bus')) {
-            return (string) $container->getAlias('messenger.default_bus');
-        }
-
-        $busIds = array_keys($container->findTaggedServiceIds('messenger.bus'));
-        if (1 === \count($busIds)) {
-            return $busIds[0];
-        }
-
-        if ($container->hasParameter('messenger.bus.default.middleware')) {
-            return 'messenger.bus.default';
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<int|string, mixed> $middleware
-     *
-     * @return array<int|string, mixed>
-     */
-    private function insertMiddleware(array $middleware, string $serviceId): array
-    {
-        if ($this->hasMiddleware($middleware, $serviceId)) {
-            return $middleware;
-        }
-
-        $position = $this->findTerminalMiddlewarePosition($middleware);
-        array_splice($middleware, $position, 0, [['id' => $serviceId]]);
-
-        return $middleware;
-    }
-
-    /**
-     * @param array<int|string, mixed> $middleware
-     */
-    private function hasMiddleware(array $middleware, string $serviceId): bool
-    {
-        foreach ($middleware as $item) {
-            $id = $this->middlewareId($item);
-            if ($serviceId === $id || 'messenger.middleware.'.$serviceId === $id) {
-                return true;
+        $position = \count($middlewares);
+        foreach ($middlewareIds as $key => $id) {
+            if (\in_array($id, self::TERMINAL_MIDDLEWARE_IDS, true)) {
+                $position = $key;
+                break;
             }
         }
 
-        return false;
-    }
+        $newMiddlewares = [
+            ...\array_slice($middlewares, 0, $position),
+            ...$middlewareToInsert,
+            ...\array_slice($middlewares, $position),
+        ];
 
-    /**
-     * @param array<int|string, mixed> $middleware
-     */
-    private function findTerminalMiddlewarePosition(array $middleware): int
-    {
-        foreach ($middleware as $position => $item) {
-            if (\in_array($this->middlewareId($item), [
-                'send_message',
-                'messenger.middleware.send_message',
-                'handle_message',
-                'messenger.middleware.handle_message',
-            ], true)) {
-                return (int) $position;
-            }
-        }
-
-        return \count($middleware);
-    }
-
-    private function middlewareId(mixed $item): ?string
-    {
-        if (\is_string($item)) {
-            return $item;
-        }
-
-        if (!\is_array($item) || !isset($item['id'])) {
-            return null;
-        }
-
-        return \is_string($item['id']) ? $item['id'] : null;
-    }
-
-    private function isMetricsEnabled(ContainerBuilder $container): bool
-    {
-        if (!$container->hasParameter('open_telemetry.metrics.enabled')) {
-            return false;
-        }
-
-        return true === $container->getParameter('open_telemetry.metrics.enabled');
+        $container->setParameter($parameter, $newMiddlewares);
     }
 }

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -41,34 +41,8 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
     public function prepend(ContainerBuilder $container): void
     {
         $configs = $container->getExtensionConfig($this->getAlias());
-        /** @var array{traces: array{enabled: bool, messenger: array{enabled: bool}}, metrics: array{enabled: bool, messenger: array{enabled: bool}}, logs: array{export: array{enabled: bool, level: string, capture_code_attributes: bool, unprefixed_attributes: bool}}} $config */
+        /** @var array{logs: array{export: array{enabled: bool, level: string, capture_code_attributes: bool, unprefixed_attributes: bool}}} $config */
         $config = $this->processConfiguration(new Configuration(), $configs);
-
-        $tracingEnabled = $config['traces']['enabled'];
-
-        if ($this->isMessengerAvailable()) {
-            $middlewares = [];
-            if ($tracingEnabled && $config['traces']['messenger']['enabled']) {
-                $middlewares[] = OpenTelemetryMiddleware::class;
-            }
-            $metrics = $config['metrics'];
-            if ($metrics['enabled'] && $metrics['messenger']['enabled']) {
-                $middlewares[] = OpenTelemetryMetricsMiddleware::class;
-            }
-            if ([] !== $middlewares) {
-                $busName = $this->getMessengerDefaultBusName($container);
-
-                $container->prependExtensionConfig('framework', [
-                    'messenger' => [
-                        'buses' => [
-                            $busName => [
-                                'middleware' => $middlewares,
-                            ],
-                        ],
-                    ],
-                ]);
-            }
-        }
 
         if ($config['logs']['export']['enabled']) {
             if (!$container->hasExtension('monolog')) {
@@ -333,24 +307,5 @@ final class OpenTelemetryExtension extends Extension implements PrependExtension
     private function isXRayAvailable(): bool
     {
         return class_exists(\OpenTelemetry\Contrib\Aws\Xray\Propagator::class);
-    }
-
-    private function getMessengerDefaultBusName(ContainerBuilder $container): string
-    {
-        $busName = null;
-
-        foreach ($container->getExtensionConfig('framework') as $frameworkConfig) {
-            if (!isset($frameworkConfig['messenger']) || !\is_array($frameworkConfig['messenger'])) {
-                continue;
-            }
-
-            $defaultBus = $frameworkConfig['messenger']['default_bus'] ?? null;
-
-            if (\is_string($defaultBus) && '' !== $defaultBus) {
-                $busName = $defaultBus;
-            }
-        }
-
-        return $busName ?? 'messenger.bus.default';
     }
 }

--- a/src/OpenTelemetryBundle.php
+++ b/src/OpenTelemetryBundle.php
@@ -8,11 +8,13 @@ use Composer\InstalledVersions;
 use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SemConv\TraceAttributes;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\CacheTracingPass;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\HttpClientMetricsPass;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\HttpClientTracingPass;
+use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\MessengerMiddlewarePass;
 
 final class OpenTelemetryBundle extends Bundle
 {
@@ -56,6 +58,7 @@ final class OpenTelemetryBundle extends Bundle
         $container->addCompilerPass(new HttpClientTracingPass());
         $container->addCompilerPass(new HttpClientMetricsPass());
         $container->addCompilerPass(new CacheTracingPass());
+        $container->addCompilerPass(new MessengerMiddlewarePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
     }
 
     public function boot(): void

--- a/src/OpenTelemetryBundle.php
+++ b/src/OpenTelemetryBundle.php
@@ -8,7 +8,6 @@ use Composer\InstalledVersions;
 use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SemConv\TraceAttributes;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\CacheTracingPass;
@@ -58,7 +57,7 @@ final class OpenTelemetryBundle extends Bundle
         $container->addCompilerPass(new HttpClientTracingPass());
         $container->addCompilerPass(new HttpClientMetricsPass());
         $container->addCompilerPass(new CacheTracingPass());
-        $container->addCompilerPass(new MessengerMiddlewarePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
+        $container->addCompilerPass(new MessengerMiddlewarePass(), priority: 10);
     }
 
     public function boot(): void

--- a/tests/DependencyInjection/Compiler/MessengerMiddlewarePassTest.php
+++ b/tests/DependencyInjection/Compiler/MessengerMiddlewarePassTest.php
@@ -13,37 +13,14 @@ use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
 
 final class MessengerMiddlewarePassTest extends TestCase
 {
-    public function testInsertsTracingMiddlewareBeforeTerminalMessengerMiddleware(): void
-    {
-        $container = $this->containerWithDefaultBus('default');
-        $container->setParameter('open_telemetry.metrics.enabled', false);
-        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
-        $container->setParameter('default.middleware', [
-            ['id' => 'add_default_stamps_middleware'],
-            ['id' => 'doctrine_ping_connection'],
-            ['id' => 'doctrine_close_connection'],
-            ['id' => 'send_message'],
-            ['id' => 'handle_message'],
-        ]);
-
-        (new MessengerMiddlewarePass())->process($container);
-
-        self::assertSame([
-            'add_default_stamps_middleware',
-            'doctrine_ping_connection',
-            'doctrine_close_connection',
-            OpenTelemetryMiddleware::class,
-            'send_message',
-            'handle_message',
-        ], $this->middlewareIds($container, 'default.middleware'));
-    }
-
-    public function testUsesConfiguredDefaultBusAlias(): void
+    public function testInsertsAvailableMiddlewareOnConfiguredDefaultBus(): void
     {
         $container = $this->containerWithDefaultBus('command.bus');
-        $container->setParameter('open_telemetry.metrics.enabled', false);
         $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setDefinition(OpenTelemetryMetricsMiddleware::class, new Definition(OpenTelemetryMetricsMiddleware::class));
         $container->setParameter('command.bus.middleware', [
+            ['id' => 'add_default_stamps_middleware'],
+            ['id' => 'application_middleware'],
             ['id' => 'send_message'],
             ['id' => 'handle_message'],
         ]);
@@ -52,95 +29,109 @@ final class MessengerMiddlewarePassTest extends TestCase
             ['id' => 'handle_message'],
         ]);
 
-        (new MessengerMiddlewarePass())->process($container);
+        $pass = new MessengerMiddlewarePass();
+        $pass->process($container);
 
-        self::assertSame([
-            OpenTelemetryMiddleware::class,
-            'send_message',
-            'handle_message',
-        ], $this->middlewareIds($container, 'command.bus.middleware'));
-        self::assertSame([
-            'send_message',
-            'handle_message',
-        ], $this->middlewareIds($container, 'event.bus.middleware'));
-    }
-
-    public function testInsertsMetricsMiddlewareWhenMetricsAreEnabled(): void
-    {
-        $container = $this->containerWithDefaultBus('default');
-        $container->setParameter('open_telemetry.metrics.enabled', true);
-        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
-        $container->setDefinition(OpenTelemetryMetricsMiddleware::class, new Definition(OpenTelemetryMetricsMiddleware::class));
-        $container->setParameter('default.middleware', [
-            ['id' => 'send_message'],
-            ['id' => 'handle_message'],
-        ]);
-
-        (new MessengerMiddlewarePass())->process($container);
-
-        self::assertSame([
-            OpenTelemetryMiddleware::class,
-            OpenTelemetryMetricsMiddleware::class,
-            'send_message',
-            'handle_message',
-        ], $this->middlewareIds($container, 'default.middleware'));
-    }
-
-    public function testDoesNotInsertMetricsMiddlewareWhenMetricsAreDisabled(): void
-    {
-        $container = $this->containerWithDefaultBus('default');
-        $container->setParameter('open_telemetry.metrics.enabled', false);
-        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
-        $container->setDefinition(OpenTelemetryMetricsMiddleware::class, new Definition(OpenTelemetryMetricsMiddleware::class));
-        $container->setParameter('default.middleware', [
-            ['id' => 'send_message'],
-            ['id' => 'handle_message'],
-        ]);
-
-        (new MessengerMiddlewarePass())->process($container);
-
-        self::assertSame([
-            OpenTelemetryMiddleware::class,
-            'send_message',
-            'handle_message',
-        ], $this->middlewareIds($container, 'default.middleware'));
+        self::assertSame(
+            [
+                'add_default_stamps_middleware',
+                'application_middleware',
+                OpenTelemetryMiddleware::class,
+                OpenTelemetryMetricsMiddleware::class,
+                'send_message',
+                'handle_message',
+            ],
+            $this->middlewareIds($container, 'command.bus.middleware'),
+        );
+        self::assertSame(
+            ['send_message', 'handle_message'],
+            $this->middlewareIds($container, 'event.bus.middleware'),
+        );
     }
 
     public function testDoesNotDuplicateManuallyConfiguredMiddleware(): void
     {
         $container = $this->containerWithDefaultBus('default');
-        $container->setParameter('open_telemetry.metrics.enabled', false);
         $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setDefinition(OpenTelemetryMetricsMiddleware::class, new Definition(OpenTelemetryMetricsMiddleware::class));
         $container->setParameter('default.middleware', [
             ['id' => OpenTelemetryMiddleware::class],
+            ['id' => 'messenger.middleware.'.OpenTelemetryMetricsMiddleware::class],
             ['id' => 'send_message'],
             ['id' => 'handle_message'],
         ]);
 
-        (new MessengerMiddlewarePass())->process($container);
+        $pass = new MessengerMiddlewarePass();
+        $pass->process($container);
 
-        self::assertSame([
-            OpenTelemetryMiddleware::class,
-            'send_message',
-            'handle_message',
-        ], $this->middlewareIds($container, 'default.middleware'));
+        self::assertSame(
+            [
+                OpenTelemetryMiddleware::class,
+                'messenger.middleware.'.OpenTelemetryMetricsMiddleware::class,
+                'send_message',
+                'handle_message',
+            ],
+            $this->middlewareIds($container, 'default.middleware'),
+        );
     }
 
-    public function testSkipsWhenMiddlewareServiceDoesNotExist(): void
+    public function testAppendsMiddlewareWhenDefaultMiddlewareIsDisabled(): void
     {
         $container = $this->containerWithDefaultBus('default');
-        $container->setParameter('open_telemetry.metrics.enabled', false);
+        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setParameter('default.middleware', [
+            ['id' => 'application_middleware'],
+        ]);
+
+        $pass = new MessengerMiddlewarePass();
+        $pass->process($container);
+
+        self::assertSame(
+            ['application_middleware', OpenTelemetryMiddleware::class],
+            $this->middlewareIds($container, 'default.middleware'),
+        );
+    }
+
+    public function testSkipsWhenMiddlewareServicesDoNotExist(): void
+    {
+        $container = $this->containerWithDefaultBus('default');
         $container->setParameter('default.middleware', [
             ['id' => 'send_message'],
             ['id' => 'handle_message'],
         ]);
 
-        (new MessengerMiddlewarePass())->process($container);
+        $pass = new MessengerMiddlewarePass();
+        $pass->process($container);
 
-        self::assertSame([
-            'send_message',
-            'handle_message',
-        ], $this->middlewareIds($container, 'default.middleware'));
+        self::assertSame(
+            ['send_message', 'handle_message'],
+            $this->middlewareIds($container, 'default.middleware'),
+        );
+    }
+
+    public function testSkipsWithoutDefaultBusAliasOrMiddlewareParameter(): void
+    {
+        $containerWithoutAlias = new ContainerBuilder();
+        $containerWithoutAlias->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $containerWithoutAlias->setParameter('default.middleware', [
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+
+        $pass = new MessengerMiddlewarePass();
+        $pass->process($containerWithoutAlias);
+
+        self::assertSame(
+            ['send_message', 'handle_message'],
+            $this->middlewareIds($containerWithoutAlias, 'default.middleware'),
+        );
+
+        $containerWithoutParameter = $this->containerWithDefaultBus('default');
+        $containerWithoutParameter->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+
+        $pass->process($containerWithoutParameter);
+
+        self::assertFalse($containerWithoutParameter->hasParameter('default.middleware'));
     }
 
     private function containerWithDefaultBus(string $busId): ContainerBuilder
@@ -152,16 +143,13 @@ final class MessengerMiddlewarePassTest extends TestCase
     }
 
     /**
-     * @return list<string|null>
+     * @return list<string>
      */
     private function middlewareIds(ContainerBuilder $container, string $parameter): array
     {
+        /** @var list<array{id: string}> $middleware */
         $middleware = $container->getParameter($parameter);
-        \assert(\is_array($middleware));
 
-        return array_map(
-            static fn (mixed $item): ?string => \is_array($item) && \is_string($item['id'] ?? null) ? $item['id'] : null,
-            array_values($middleware),
-        );
+        return array_column($middleware, 'id');
     }
 }

--- a/tests/DependencyInjection/Compiler/MessengerMiddlewarePassTest.php
+++ b/tests/DependencyInjection/Compiler/MessengerMiddlewarePassTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\MessengerMiddlewarePass;
+use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMetricsMiddleware;
+use Traceway\OpenTelemetryBundle\Messenger\OpenTelemetryMiddleware;
+
+final class MessengerMiddlewarePassTest extends TestCase
+{
+    public function testInsertsTracingMiddlewareBeforeTerminalMessengerMiddleware(): void
+    {
+        $container = $this->containerWithDefaultBus('default');
+        $container->setParameter('open_telemetry.metrics.enabled', false);
+        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setParameter('default.middleware', [
+            ['id' => 'add_default_stamps_middleware'],
+            ['id' => 'doctrine_ping_connection'],
+            ['id' => 'doctrine_close_connection'],
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+
+        (new MessengerMiddlewarePass())->process($container);
+
+        self::assertSame([
+            'add_default_stamps_middleware',
+            'doctrine_ping_connection',
+            'doctrine_close_connection',
+            OpenTelemetryMiddleware::class,
+            'send_message',
+            'handle_message',
+        ], $this->middlewareIds($container, 'default.middleware'));
+    }
+
+    public function testUsesConfiguredDefaultBusAlias(): void
+    {
+        $container = $this->containerWithDefaultBus('command.bus');
+        $container->setParameter('open_telemetry.metrics.enabled', false);
+        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setParameter('command.bus.middleware', [
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+        $container->setParameter('event.bus.middleware', [
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+
+        (new MessengerMiddlewarePass())->process($container);
+
+        self::assertSame([
+            OpenTelemetryMiddleware::class,
+            'send_message',
+            'handle_message',
+        ], $this->middlewareIds($container, 'command.bus.middleware'));
+        self::assertSame([
+            'send_message',
+            'handle_message',
+        ], $this->middlewareIds($container, 'event.bus.middleware'));
+    }
+
+    public function testInsertsMetricsMiddlewareWhenMetricsAreEnabled(): void
+    {
+        $container = $this->containerWithDefaultBus('default');
+        $container->setParameter('open_telemetry.metrics.enabled', true);
+        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setDefinition(OpenTelemetryMetricsMiddleware::class, new Definition(OpenTelemetryMetricsMiddleware::class));
+        $container->setParameter('default.middleware', [
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+
+        (new MessengerMiddlewarePass())->process($container);
+
+        self::assertSame([
+            OpenTelemetryMiddleware::class,
+            OpenTelemetryMetricsMiddleware::class,
+            'send_message',
+            'handle_message',
+        ], $this->middlewareIds($container, 'default.middleware'));
+    }
+
+    public function testDoesNotInsertMetricsMiddlewareWhenMetricsAreDisabled(): void
+    {
+        $container = $this->containerWithDefaultBus('default');
+        $container->setParameter('open_telemetry.metrics.enabled', false);
+        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setDefinition(OpenTelemetryMetricsMiddleware::class, new Definition(OpenTelemetryMetricsMiddleware::class));
+        $container->setParameter('default.middleware', [
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+
+        (new MessengerMiddlewarePass())->process($container);
+
+        self::assertSame([
+            OpenTelemetryMiddleware::class,
+            'send_message',
+            'handle_message',
+        ], $this->middlewareIds($container, 'default.middleware'));
+    }
+
+    public function testDoesNotDuplicateManuallyConfiguredMiddleware(): void
+    {
+        $container = $this->containerWithDefaultBus('default');
+        $container->setParameter('open_telemetry.metrics.enabled', false);
+        $container->setDefinition(OpenTelemetryMiddleware::class, new Definition(OpenTelemetryMiddleware::class));
+        $container->setParameter('default.middleware', [
+            ['id' => OpenTelemetryMiddleware::class],
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+
+        (new MessengerMiddlewarePass())->process($container);
+
+        self::assertSame([
+            OpenTelemetryMiddleware::class,
+            'send_message',
+            'handle_message',
+        ], $this->middlewareIds($container, 'default.middleware'));
+    }
+
+    public function testSkipsWhenMiddlewareServiceDoesNotExist(): void
+    {
+        $container = $this->containerWithDefaultBus('default');
+        $container->setParameter('open_telemetry.metrics.enabled', false);
+        $container->setParameter('default.middleware', [
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ]);
+
+        (new MessengerMiddlewarePass())->process($container);
+
+        self::assertSame([
+            'send_message',
+            'handle_message',
+        ], $this->middlewareIds($container, 'default.middleware'));
+    }
+
+    private function containerWithDefaultBus(string $busId): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setAlias('messenger.default_bus', $busId);
+
+        return $container;
+    }
+
+    /**
+     * @return list<string|null>
+     */
+    private function middlewareIds(ContainerBuilder $container, string $parameter): array
+    {
+        $middleware = $container->getParameter($parameter);
+        \assert(\is_array($middleware));
+
+        return array_map(
+            static fn (mixed $item): ?string => \is_array($item) && \is_string($item['id'] ?? null) ? $item['id'] : null,
+            array_values($middleware),
+        );
+    }
+}

--- a/tests/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -165,72 +165,13 @@ final class OpenTelemetryExtensionTest extends TestCase
         self::assertFalse($def->getArgument('$rootSpans'));
     }
 
-    public function testPrependRegistersMessengerMiddleware(): void
+    public function testPrependDoesNotInjectMessengerMiddlewareConfig(): void
     {
         $container = new ContainerBuilder();
         $extension = new OpenTelemetryExtension();
         $extension->prepend($container);
 
-        $frameworkConfigs = $container->getExtensionConfig('framework');
-        self::assertNotEmpty($frameworkConfigs);
-
-        $messengerConfig = $frameworkConfigs[0]['messenger'] ?? null;
-        self::assertNotNull($messengerConfig);
-
-        $middleware = $messengerConfig['buses']['messenger.bus.default']['middleware'] ?? [];
-        self::assertContains(OpenTelemetryMiddleware::class, $middleware);
-    }
-
-    public function testPrependRegistersMessengerMiddlewareOnConfiguredDefaultBus(): void
-    {
-        $container = new ContainerBuilder();
-        $container->prependExtensionConfig('framework', [
-            'messenger' => [
-                'default_bus' => 'messenger.bus.commands',
-            ],
-        ]);
-
-        $extension = new OpenTelemetryExtension();
-        $extension->prepend($container);
-
-        $frameworkConfigs = $container->getExtensionConfig('framework');
-        self::assertNotEmpty($frameworkConfigs);
-
-        $messengerConfig = $frameworkConfigs[0]['messenger'] ?? null;
-        self::assertNotNull($messengerConfig);
-
-        $middleware = $messengerConfig['buses']['messenger.bus.commands']['middleware'] ?? [];
-        self::assertContains(OpenTelemetryMiddleware::class, $middleware);
-        self::assertArrayNotHasKey('messenger.bus.default', $messengerConfig['buses']);
-    }
-
-    public function testPrependSkippedWhenMessengerDisabled(): void
-    {
-        $container = new ContainerBuilder();
-        $container->prependExtensionConfig('open_telemetry', ['traces' => ['messenger' => ['enabled' => false]]]);
-
-        $extension = new OpenTelemetryExtension();
-        $extension->prepend($container);
-
-        $frameworkConfigs = $container->getExtensionConfig('framework');
-        self::assertEmpty($frameworkConfigs);
-    }
-
-    public function testPrependSkippedWhenTracesDisabled(): void
-    {
-        $container = new ContainerBuilder();
-        $container->prependExtensionConfig('open_telemetry', [
-            'traces' => [
-                'enabled' => false,
-                'messenger' => ['enabled' => true],
-            ],
-        ]);
-
-        $extension = new OpenTelemetryExtension();
-        $extension->prepend($container);
-
-        $frameworkConfigs = $container->getExtensionConfig('framework');
-        self::assertEmpty($frameworkConfigs);
+        self::assertSame([], $container->getExtensionConfig('framework'));
     }
 
     public function testDoctrineMiddlewareRegisteredWhenEnabled(): void

--- a/tests/Functional/BundleBootTest.php
+++ b/tests/Functional/BundleBootTest.php
@@ -7,6 +7,7 @@ namespace Traceway\OpenTelemetryBundle\Tests\Functional;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Traceway\OpenTelemetryBundle\Command\Doctor\Support\CheckRunner;
 use Traceway\OpenTelemetryBundle\Command\DoctorCommand;
 use Traceway\OpenTelemetryBundle\Doctrine\Middleware\MeteredMiddleware as DoctrineMeteredMiddleware;
@@ -255,6 +256,36 @@ final class BundleBootTest extends TestCase
         );
     }
 
+    public function testMessengerMiddlewareIsWiredWhenApplicationDefinesBusMiddleware(): void
+    {
+        $container = $this->boot([], [], [
+            'messenger' => [
+                'default_bus' => 'default',
+                'buses' => [
+                    'default' => [
+                        'middleware' => [
+                            NoopMessengerMiddleware::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $middlewareClasses = $this->messengerMiddlewareClasses($container->get('messenger.default_bus'));
+
+        self::assertContains(NoopMessengerMiddleware::class, $middlewareClasses);
+        self::assertContains(OpenTelemetryMiddleware::class, $middlewareClasses);
+        self::assertContains(SendMessageMiddleware::class, $middlewareClasses);
+        self::assertLessThan(
+            array_search(OpenTelemetryMiddleware::class, $middlewareClasses, true),
+            array_search(NoopMessengerMiddleware::class, $middlewareClasses, true),
+        );
+        self::assertLessThan(
+            array_search(SendMessageMiddleware::class, $middlewareClasses, true),
+            array_search(OpenTelemetryMiddleware::class, $middlewareClasses, true),
+        );
+    }
+
     public function testMessengerMetricsWithoutMetricsEnabledFails(): void
     {
         $this->expectException(InvalidConfigurationException::class);
@@ -460,12 +491,28 @@ final class BundleBootTest extends TestCase
     /**
      * @param array<string, mixed>                                       $otelConfig
      * @param list<\Symfony\Component\HttpKernel\Bundle\BundleInterface> $extraBundles
+     * @param array<string, mixed>                                       $frameworkConfig
      */
-    private function boot(array $otelConfig = [], array $extraBundles = []): \Symfony\Component\DependencyInjection\ContainerInterface
+    private function boot(array $otelConfig = [], array $extraBundles = [], array $frameworkConfig = []): \Symfony\Component\DependencyInjection\ContainerInterface
     {
-        $this->kernel = new OpenTelemetryTestKernel($otelConfig, $extraBundles);
+        $this->kernel = new OpenTelemetryTestKernel($otelConfig, $extraBundles, $frameworkConfig);
         $this->kernel->boot();
 
         return $this->kernel->getContainer();
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function messengerMiddlewareClasses(object $messageBus): array
+    {
+        $reflection = new \ReflectionClass($messageBus);
+        $property = $reflection->getProperty('middlewareAggregate');
+        $middleware = iterator_to_array($property->getValue($messageBus), false);
+
+        return array_map(
+            static fn (object $middleware): string => $middleware::class,
+            $middleware,
+        );
     }
 }

--- a/tests/Functional/BundleBootTest.php
+++ b/tests/Functional/BundleBootTest.php
@@ -276,14 +276,6 @@ final class BundleBootTest extends TestCase
         self::assertContains(NoopMessengerMiddleware::class, $middlewareClasses);
         self::assertContains(OpenTelemetryMiddleware::class, $middlewareClasses);
         self::assertContains(SendMessageMiddleware::class, $middlewareClasses);
-        self::assertLessThan(
-            array_search(OpenTelemetryMiddleware::class, $middlewareClasses, true),
-            array_search(NoopMessengerMiddleware::class, $middlewareClasses, true),
-        );
-        self::assertLessThan(
-            array_search(SendMessageMiddleware::class, $middlewareClasses, true),
-            array_search(OpenTelemetryMiddleware::class, $middlewareClasses, true),
-        );
     }
 
     public function testMessengerMetricsWithoutMetricsEnabledFails(): void
@@ -506,8 +498,7 @@ final class BundleBootTest extends TestCase
      */
     private function messengerMiddlewareClasses(object $messageBus): array
     {
-        $reflection = new \ReflectionClass($messageBus);
-        $property = $reflection->getProperty('middlewareAggregate');
+        $property = new \ReflectionProperty($messageBus, 'middlewareAggregate');
         $middleware = iterator_to_array($property->getValue($messageBus), false);
 
         return array_map(

--- a/tests/Functional/NoopMessengerMiddleware.php
+++ b/tests/Functional/NoopMessengerMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Traceway\OpenTelemetryBundle\Tests\Functional;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+final class NoopMessengerMiddleware implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/tests/Functional/OpenTelemetryTestKernel.php
+++ b/tests/Functional/OpenTelemetryTestKernel.php
@@ -7,6 +7,7 @@ namespace Traceway\OpenTelemetryBundle\Tests\Functional;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\Kernel;
 use Traceway\OpenTelemetryBundle\OpenTelemetryBundle;
 
@@ -34,17 +35,23 @@ final class OpenTelemetryTestKernel extends Kernel
     /** @var list<\Symfony\Component\HttpKernel\Bundle\BundleInterface> */
     private array $extraBundles;
 
+    /** @var array<string, mixed> */
+    private array $frameworkConfig;
+
     /**
      * @param array<string, mixed>                                       $otelConfig
      * @param list<\Symfony\Component\HttpKernel\Bundle\BundleInterface> $extraBundles
+     * @param array<string, mixed>                                       $frameworkConfig
      */
     public function __construct(
         array $otelConfig = [],
         array $extraBundles = [],
+        array $frameworkConfig = [],
     ) {
         $this->instanceId = ++self::$instanceCounter;
         $this->otelConfig = $otelConfig;
         $this->extraBundles = $extraBundles;
+        $this->frameworkConfig = $frameworkConfig;
 
         parent::__construct('test', false);
     }
@@ -63,13 +70,18 @@ final class OpenTelemetryTestKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $otelConfig = $this->otelConfig;
+        $frameworkConfig = $this->frameworkConfig;
 
-        $loader->load(static function (ContainerBuilder $container) use ($otelConfig): void {
-            $container->loadFromExtension('framework', [
+        $loader->load(static function (ContainerBuilder $container) use ($otelConfig, $frameworkConfig): void {
+            $container->loadFromExtension('framework', array_replace_recursive([
                 'secret' => 'test',
                 'test' => true,
                 'http_method_override' => false,
-            ]);
+            ], $frameworkConfig));
+
+            if (class_exists(NoopMessengerMiddleware::class)) {
+                $container->setDefinition(NoopMessengerMiddleware::class, new Definition(NoopMessengerMiddleware::class));
+            }
 
             if ([] !== $otelConfig) {
                 $container->loadFromExtension('open_telemetry', $otelConfig);

--- a/tests/Functional/OpenTelemetryTestKernel.php
+++ b/tests/Functional/OpenTelemetryTestKernel.php
@@ -79,9 +79,7 @@ final class OpenTelemetryTestKernel extends Kernel
                 'http_method_override' => false,
             ], $frameworkConfig));
 
-            if (class_exists(NoopMessengerMiddleware::class)) {
-                $container->setDefinition(NoopMessengerMiddleware::class, new Definition(NoopMessengerMiddleware::class));
-            }
+            $container->setDefinition(NoopMessengerMiddleware::class, new Definition(NoopMessengerMiddleware::class));
 
             if ([] !== $otelConfig) {
                 $container->loadFromExtension('open_telemetry', $otelConfig);

--- a/tests/OpenTelemetryBundleTest.php
+++ b/tests/OpenTelemetryBundleTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\CacheTracingPass;
 use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\HttpClientTracingPass;
+use Traceway\OpenTelemetryBundle\DependencyInjection\Compiler\MessengerMiddlewarePass;
 use Traceway\OpenTelemetryBundle\OpenTelemetryBundle;
 
 final class OpenTelemetryBundleTest extends TestCase
@@ -57,6 +58,24 @@ final class OpenTelemetryBundleTest extends TestCase
         }
 
         self::assertTrue($found, 'CacheTracingPass should be registered');
+    }
+
+    public function testBuildRegistersMessengerMiddlewarePass(): void
+    {
+        $container = new ContainerBuilder();
+        $bundle = new OpenTelemetryBundle();
+        $bundle->build($container);
+
+        $passes = $container->getCompilerPassConfig()->getBeforeOptimizationPasses();
+        $found = false;
+        foreach ($passes as $pass) {
+            if ($pass instanceof MessengerMiddlewarePass) {
+                $found = true;
+                break;
+            }
+        }
+
+        self::assertTrue($found, 'MessengerMiddlewarePass should be registered');
     }
 
     public function testBootDoesNotSetOpenTelemetryConfigWithoutConfiguration(): void


### PR DESCRIPTION
Hi, everyone! I noticed, that when an application adds its own middleware to a Symfony Messenger bus, OpenTelemetry middleware from the bundle is no longer registered. For example, this configuration removes OpenTelemetry middleware from the resulting middleware stack:
```
framework:
    messenger:
        buses:
            messenger.bus.default:
                middleware:
                    - App\Messenger\Middleware\CustomMiddleware
```

The problem is that Symfony does not deep merge the middleware option. Right now the bundle prepends its middleware through FrameworkBundle configuration, but application configuration replaces the prepended middleware list.


I propose moving OpenTelemetry middleware registration to a compiler pass. The compiler pass will update the middleware stack after FrameworkBundle has normalized Messenger configuration, but before Symfony builds the buses.

With this change application middleware will be preserved, tracing and metrics middleware will be added before `send_message` and `handle_message`, and the configured `default_bus` will still be respected. Manually configured OpenTelemetry middleware will also not be added twice.