### PR TITLE
Add Gauge metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Recommended-tier semconv attributes** — `network.peer.address`/`network.peer.port` on HTTP SERVER spans (the immediate TCP peer, distinct from the proxy-resolved `client.address`), and `network.protocol.version` on HTTP server and client duration/body-size metrics (deliberately not on `http.server.active_requests`, which the spec's attribute table excludes).
 - **End-to-end test harness (`e2e/`)** — boots a real kernel, exports over a real OTLP `http/json` pipeline to a real collector, and asserts on the spans the collector received; runs in CI (`.github/workflows/e2e.yml`). Catches the silent-export failure class that mocked tests cannot.
 - **`docs/semantic-conventions.md`** — the conformance statement, deliberate deviations, and known limitations; the README was slimmed to standard bundle shape with details moved into `docs/`.
+- **Gauge metric** — added support for gauge metrics in the MeterRegistry.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Mock in tests with `$this->createStub(TracingInterface::class)` and have `trace(
 
 ## Metrics
 
-Opt-in OpenTelemetry metrics — Messenger, Doctrine DBAL, HTTP server/client, and Mailer — alongside a `MeterRegistryInterface` for custom counters/histograms. See **[docs/metrics.md](docs/metrics.md)**.
+Opt-in OpenTelemetry metrics — Messenger, Doctrine DBAL, HTTP server/client, and Mailer — alongside a `MeterRegistryInterface` for custom counters/histograms/gauges. See **[docs/metrics.md](docs/metrics.md)**.
 
 ## Doctor
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -55,7 +55,7 @@ Decoration sits inside `TraceableTransports` so metric points record while the t
 
 ## Manual Metrics
 
-Inject `MeterRegistryInterface` to record your own counters, histograms, and up/down counters without touching the `MeterProvider` directly:
+Inject `MeterRegistryInterface` to record your own counters, histograms, up/down counters, and gauges without touching the `MeterProvider` directly:
 
 ```php
 use OpenTelemetry\API\Metrics\CounterInterface;

--- a/src/Metrics/MeterRegistry.php
+++ b/src/Metrics/MeterRegistry.php
@@ -6,6 +6,7 @@ namespace Traceway\OpenTelemetryBundle\Metrics;
 
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\GaugeInterface;
 use OpenTelemetry\API\Metrics\HistogramInterface;
 use OpenTelemetry\API\Metrics\UpDownCounterInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -36,6 +37,9 @@ final class MeterRegistry implements MeterRegistryInterface, ResetInterface
     /** @var array<string, UpDownCounterInterface> */
     private array $upDownCounters = [];
 
+    /** @var array<string, GaugeInterface> */
+    private array $gauges = [];
+
     public function __construct(
         private readonly string $meterName = 'opentelemetry-symfony',
     ) {
@@ -57,11 +61,17 @@ final class MeterRegistry implements MeterRegistryInterface, ResetInterface
         return $this->upDownCounters[$name."\0".$unit] ??= $this->getMeter()->createUpDownCounter($name, $unit, $description);
     }
 
+    public function gauge(string $name, ?string $unit = null, ?string $description = null): GaugeInterface
+    {
+        return $this->gauges[$name."\0".$unit] ??= $this->getMeter()->createGauge($name, $unit, $description);
+    }
+
     public function reset(): void
     {
         $this->resetMeter();
         $this->counters = [];
         $this->histograms = [];
         $this->upDownCounters = [];
+        $this->gauges = [];
     }
 }

--- a/src/Metrics/MeterRegistryInterface.php
+++ b/src/Metrics/MeterRegistryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Traceway\OpenTelemetryBundle\Metrics;
 
 use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\GaugeInterface;
 use OpenTelemetry\API\Metrics\HistogramInterface;
 use OpenTelemetry\API\Metrics\UpDownCounterInterface;
 
@@ -21,4 +22,6 @@ interface MeterRegistryInterface
     public function histogram(string $name, ?string $unit = null, ?string $description = null): HistogramInterface;
 
     public function upDownCounter(string $name, ?string $unit = null, ?string $description = null): UpDownCounterInterface;
+
+    public function gauge(string $name, ?string $unit = null, ?string $description = null): GaugeInterface;
 }

--- a/tests/Metrics/MeterRegistryTest.php
+++ b/tests/Metrics/MeterRegistryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Traceway\OpenTelemetryBundle\Tests\Metrics;
 
+use OpenTelemetry\SDK\Metrics\Data\Gauge;
 use OpenTelemetry\SDK\Metrics\Data\Sum;
 use PHPUnit\Framework\TestCase;
 use Traceway\OpenTelemetryBundle\Metrics\MeterRegistry;
@@ -63,6 +64,27 @@ final class MeterRegistryTest extends TestCase
         $metric = $metrics['my.counter'];
         self::assertSame('desc', $metric->description);
         self::assertInstanceOf(Sum::class, $metric->data);
+
+        $byTag = [];
+        foreach ($metric->data->dataPoints as $dp) {
+            $byTag[(string) $dp->attributes->toArray()['tag']] = $dp->value;
+        }
+        self::assertSame(3, $byTag['a']);
+        self::assertSame(1, $byTag['b']);
+    }
+
+    public function testGaugeEmitsValuesAndAttributes(): void
+    {
+        $registry = new MeterRegistry('test');
+        $registry->gauge('my.gauge', description: 'a gauge')->record(3, ['tag' => 'a']);
+        $registry->gauge('my.gauge')->record(1, ['tag' => 'b']);
+
+        $metrics = $this->collectMetrics();
+
+        self::assertArrayHasKey('my.gauge', $metrics);
+        $metric = $metrics['my.gauge'];
+        self::assertSame('a gauge', $metric->description);
+        self::assertInstanceOf(Gauge::class, $metric->data);
 
         $byTag = [];
         foreach ($metric->data->dataPoints as $dp) {

--- a/tests/Metrics/MeterRegistryTest.php
+++ b/tests/Metrics/MeterRegistryTest.php
@@ -44,6 +44,13 @@ final class MeterRegistryTest extends TestCase
         self::assertSame($registry->upDownCounter('foo'), $registry->upDownCounter('foo'));
     }
 
+    public function testGaugeReturnsSameInstanceForSameName(): void
+    {
+        $registry = new MeterRegistry('test');
+
+        self::assertSame($registry->gauge('foo'), $registry->gauge('foo'));
+    }
+
     public function testCounterEmitsValuesAndAttributes(): void
     {
         $registry = new MeterRegistry('test');


### PR DESCRIPTION
Add support for gauge metrics to the `MeterRegistry`, aligning the API with OpenTelemetry's metric types and improving metric instrumentation flexibility.